### PR TITLE
Implement encryption

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ compiler:
 addons:
   apt:
     sources:
-    - sourceline: 'ppa:chris-lea/libsodium'
+    - sourceline: 'deb http://archive.ubuntu.com/ubuntu disco main'
     packages:
     - libsodium-dev
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,7 @@ script:
   # -- Run CMake --
   - mkdir build
   - cd build
-  - cmake ../ -DENABLE_ENCRYPTION=1 -sodium_USE_STATIC_LIBS=1 -DWARNINGS_PEDANTIC=1 -DWARNINGS_AS_ERRORS=1 -DCMAKE_BUILD_TYPE=Debug -DBUILD_TESTS=1
+  - cmake ../ -DENABLE_ENCRYPTION=1 -Dsodium_USE_STATIC_LIBS=1 -DWARNINGS_PEDANTIC=1 -DWARNINGS_AS_ERRORS=1 -DCMAKE_BUILD_TYPE=Debug -DBUILD_TESTS=1
   # -- Compile --
   - $CXX --version
   - make -j 4 -k

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,7 @@ script:
   # -- Run CMake --
   - mkdir build
   - cd build
-  - cmake ../ -DENABLE_ENCRYPTION=1 -DWARNINGS_PEDANTIC=1 -DWARNINGS_AS_ERRORS=1 -DCMAKE_BUILD_TYPE=Debug -DBUILD_TESTS=1
+  - cmake ../ -DENABLE_ENCRYPTION=1 -sodium_USE_STATIC_LIBS=1 -DWARNINGS_PEDANTIC=1 -DWARNINGS_AS_ERRORS=1 -DCMAKE_BUILD_TYPE=Debug -DBUILD_TESTS=1
   # -- Compile --
   - $CXX --version
   - make -j 4 -k

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,15 +1,23 @@
 dist: xenial
+cache: packages
 
 language: cpp
 compiler:
   - gcc
   - clang
 
+addons:
+  apt:
+    sources:
+    - sourceline: 'ppa:chris-lea/libsodium'
+    packages:
+    - libsodium-dev
+
 script:
   # -- Run CMake --
   - mkdir build
   - cd build
-  - cmake ../ -DWARNINGS_PEDANTIC=1 -DWARNINGS_AS_ERRORS=1 -DCMAKE_BUILD_TYPE=Debug -DBUILD_TESTS=1
+  - cmake ../ -DENABLE_ENCRYPTION=1 -DWARNINGS_PEDANTIC=1 -DWARNINGS_AS_ERRORS=1 -DCMAKE_BUILD_TYPE=Debug -DBUILD_TESTS=1
   # -- Compile --
   - $CXX --version
   - make -j 4 -k

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,6 +5,7 @@ if (POLICY CMP0076)
   cmake_policy(SET CMP0076 NEW) # target_sources makes paths absolute
 endif()
 
+option(ENABLE_ENCRYPTION "Enable cryptographic features. Requires libsodium." OFF)
 option(BUILD_SHARED_LIBS "Make shared library instead of static library" OFF)
 option(BUILD_C_BINDINGS "Build the C bindings library. You need this if you want to use C#." ON)
 option(BUILD_CSHARP_BINDINGS "Build the C# bindings library. Requires a C# compiler, obviously." OFF)
@@ -50,6 +51,13 @@ target_link_libraries(Wirefox PRIVATE wirefox-platform-interface)
 # import native threading library
 find_package(Threads REQUIRED)
 target_link_libraries(Wirefox PRIVATE Threads::Threads)
+
+# import libsodium for cryptography
+if(ENABLE_ENCRYPTION)
+  find_package(sodium REQUIRED)
+  target_link_libraries(Wirefox PRIVATE sodium)
+  add_definitions(-DWIREFOX_ENABLE_ENCRYPTION)
+endif()
 
 # can't get pch to work on gcc/clang for now so just leave it I guess
 if (CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")

--- a/Doxyfile
+++ b/Doxyfile
@@ -2152,7 +2152,7 @@ INCLUDE_FILE_PATTERNS  =
 # recursively expanded use the := operator instead of the = operator.
 # This tag requires that the tag ENABLE_PREPROCESSING is set to YES.
 
-PREDEFINED             = WIREFOX_API=
+PREDEFINED             = WIREFOX_API= WIREFOX_ENABLE_ENCRYPTION=1
 
 # If the MACRO_EXPANSION and EXPAND_ONLY_PREDEF tags are set to YES then this
 # tag can be used to specify a list of macro names that should be expanded. The

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -12,11 +12,11 @@ install:
   # install libsodium
 - ps: >-
     if(!(Test-Path -Path "deps")){
-    mkdir deps
-    cd deps
-    appveyor-retry appveyor DownloadFile https://download.libsodium.org/libsodium/releases/libsodium-1.0.17-stable-msvc.zip -FileName libsodium.zip
-    7z x libsodium.zip -olibsodium
-    del libsodium.zip
+    mkdir deps;
+    cd deps;
+    appveyor-retry appveyor DownloadFile https://download.libsodium.org/libsodium/releases/libsodium-1.0.17-stable-msvc.zip -FileName libsodium.zip;
+    7z x libsodium.zip -olibsodium;
+    del libsodium.zip;
     cd ..
     }
 - cmd: set sodium_DIR=%APPVEYOR_BUILD_FOLDER%\deps\libsodium

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -10,15 +10,16 @@ configuration:
 
 install:
   # install libsodium
-- cmd: >-
-    if not exist deps\ (
-        mkdir deps && cd deps
-        appveyor-retry appveyor DownloadFile https://download.libsodium.org/libsodium/releases/libsodium-1.0.17-stable-msvc.zip -FileName libsodium.zip
-        7z x libsodium.zip -olibsodium
-        del /F libsodium.zip
-        set sodium_DIR=%APPVEYOR_BUILD_FOLDER%\deps\libsodium
-        cd ..
-        )
+- ps: >-
+    if(!(Test-Path -Path "deps")){
+    mkdir deps
+    cd deps
+    appveyor-retry appveyor DownloadFile https://download.libsodium.org/libsodium/releases/libsodium-1.0.17-stable-msvc.zip -FileName libsodium.zip
+    7z x libsodium.zip -olibsodium
+    del libsodium.zip
+    cd ..
+    }
+- cmd: set sodium_DIR=%APPVEYOR_BUILD_FOLDER%\deps\libsodium
 
 cache:
   # preserve deps folder, but clear if this script changes

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -10,15 +10,15 @@ configuration:
 
 install:
   # install libsodium
-  - |-
+- cmd: >-
     if not exist deps\ (
-    mkdir deps && cd deps
-    appveyor-retry appveyor DownloadFile https://download.libsodium.org/libsodium/releases/libsodium-1.0.17-stable-msvc.zip -FileName libsodium.zip
-    7z x libsodium.zip -olibsodium
-    del /F libsodium.zip
-    set sodium_DIR=%APPVEYOR_BUILD_FOLDER%\deps\libsodium
-    cd ..
-    )
+        mkdir deps && cd deps
+        appveyor-retry appveyor DownloadFile https://download.libsodium.org/libsodium/releases/libsodium-1.0.17-stable-msvc.zip -FileName libsodium.zip
+        7z x libsodium.zip -olibsodium
+        del /F libsodium.zip
+        set sodium_DIR=%APPVEYOR_BUILD_FOLDER%\deps\libsodium
+        cd ..
+        )
 
 cache:
   # preserve deps folder, but clear if this script changes
@@ -27,7 +27,7 @@ cache:
 before_build:
   - mkdir build
   - cd build
-  - cmake -G "Visual Studio 15 2017 Win64" ..\ -DENABLE_ENCRYPTION=1 -sodium_USE_STATIC_LIBS=1 -DWARNINGS_PEDANTIC=1 -DWARNINGS_AS_ERRORS=1 -DBUILD_TESTS=1
+  - cmake -G "Visual Studio 15 2017 Win64" ..\ -DENABLE_ENCRYPTION=1 -Dsodium_USE_STATIC_LIBS=1 -DWARNINGS_PEDANTIC=1 -DWARNINGS_AS_ERRORS=1 -DBUILD_TESTS=1
 
 build:
   verbosity: minimal

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -10,22 +10,24 @@ configuration:
 
 install:
   # install libsodium
-  - mkdir deps && cd deps
-  - appveyor-retry appveyor DownloadFile https://download.libsodium.org/libsodium/releases/libsodium-1.0.17-stable-msvc.zip -FileName libsodium.zip
-  - 7z x libsodium.zip -olibsodium
-  - del /F libsodium.zip
-  - set sodium_USE_STATIC_LIBS=1
-  - set sodium_DIR=%APPVEYOR_BUILD_FOLDER%\deps\libsodium
-  - cd ..
+  - |-
+    if not exist deps\ (
+    mkdir deps && cd deps
+    appveyor-retry appveyor DownloadFile https://download.libsodium.org/libsodium/releases/libsodium-1.0.17-stable-msvc.zip -FileName libsodium.zip
+    7z x libsodium.zip -olibsodium
+    del /F libsodium.zip
+    set sodium_DIR=%APPVEYOR_BUILD_FOLDER%\deps\libsodium
+    cd ..
+    )
 
-#cache:
+cache:
   # preserve deps folder, but clear if this script changes
-  #- deps -> appveyor.yml
+  - deps -> appveyor.yml
 
 before_build:
   - mkdir build
   - cd build
-  - cmake -G "Visual Studio 15 2017 Win64" ..\ -DENABLE_ENCRYPTION=1 -DWARNINGS_PEDANTIC=1 -DWARNINGS_AS_ERRORS=1 -DBUILD_TESTS=1
+  - cmake -G "Visual Studio 15 2017 Win64" ..\ -DENABLE_ENCRYPTION=1 -sodium_USE_STATIC_LIBS=1 -DWARNINGS_PEDANTIC=1 -DWARNINGS_AS_ERRORS=1 -DBUILD_TESTS=1
 
 build:
   verbosity: minimal

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -8,14 +8,28 @@ configuration:
 - Debug
 - RelWithDebInfo
 
+install:
+  # install libsodium
+  - mkdir deps && cd deps
+  - appveyor-retry appveyor DownloadFile https://download.libsodium.org/libsodium/releases/libsodium-1.0.17-stable-msvc.zip -FileName libsodium.zip
+  - 7z x libsodium.zip -olibsodium
+  - del /F libsodium.zip
+  - set sodium_USE_STATIC_LIBS=1
+  - set sodium_DIR=%APPVEYOR_BUILD_FOLDER%\deps\libsodium
+  - cd ..
+
+#cache:
+  # preserve deps folder, but clear if this script changes
+  #- deps -> appveyor.yml
+
 before_build:
   - mkdir build
   - cd build
-  - cmake -G "Visual Studio 15 2017 Win64" ..\ -DWARNINGS_PEDANTIC=1 -DWARNINGS_AS_ERRORS=1 -DBUILD_TESTS=1
+  - cmake -G "Visual Studio 15 2017 Win64" ..\ -DENABLE_ENCRYPTION=1 -DWARNINGS_PEDANTIC=1 -DWARNINGS_AS_ERRORS=1 -DBUILD_TESTS=1
 
 build:
   verbosity: minimal
   project: $(APPVEYOR_BUILD_FOLDER)\build\$(APPVEYOR_PROJECT_NAME).sln
 
-#test_script:
-  #- '%APPVEYOR_BUILD_FOLDER%\build\tests\%CONFIGURATION%\tests.exe'
+test_script:
+  - '%APPVEYOR_BUILD_FOLDER%\build\tests\%CONFIGURATION%\tests.exe'

--- a/cmake/Findsodium.cmake
+++ b/cmake/Findsodium.cmake
@@ -1,0 +1,290 @@
+# Written in 2016 by Henrik Steffen Gaßmann <henrik@gassmann.onl>
+#
+# To the extent possible under law, the author(s) have dedicated all
+# copyright and related and neighboring rights to this software to the
+# public domain worldwide. This software is distributed without any warranty.
+#
+# You should have received a copy of the CC0 Public Domain Dedication
+# along with this software. If not, see
+#
+#     http://creativecommons.org/publicdomain/zero/1.0/
+#
+########################################################################
+# Tries to find the local libsodium installation.
+#
+# On Windows the sodium_DIR environment variable is used as a default
+# hint which can be overridden by setting the corresponding cmake variable.
+#
+# Once done the following variables will be defined:
+#
+#   sodium_FOUND
+#   sodium_INCLUDE_DIR
+#   sodium_LIBRARY_DEBUG
+#   sodium_LIBRARY_RELEASE
+#
+#
+# Furthermore an imported "sodium" target is created.
+#
+
+if (CMAKE_C_COMPILER_ID STREQUAL "GNU"
+    OR CMAKE_C_COMPILER_ID STREQUAL "Clang")
+    set(_GCC_COMPATIBLE 1)
+endif()
+
+# static library option
+if (NOT DEFINED sodium_USE_STATIC_LIBS)
+    option(sodium_USE_STATIC_LIBS "enable to statically link against sodium" OFF)
+endif()
+if(NOT (sodium_USE_STATIC_LIBS EQUAL sodium_USE_STATIC_LIBS_LAST))
+    unset(sodium_LIBRARY CACHE)
+    unset(sodium_LIBRARY_DEBUG CACHE)
+    unset(sodium_LIBRARY_RELEASE CACHE)
+    unset(sodium_DLL_DEBUG CACHE)
+    unset(sodium_DLL_RELEASE CACHE)
+    set(sodium_USE_STATIC_LIBS_LAST ${sodium_USE_STATIC_LIBS} CACHE INTERNAL "internal change tracking variable")
+endif()
+
+
+########################################################################
+# UNIX
+if (UNIX)
+    # import pkg-config
+    find_package(PkgConfig QUIET)
+    if (PKG_CONFIG_FOUND)
+        pkg_check_modules(sodium_PKG QUIET libsodium)
+    endif()
+
+    if(sodium_USE_STATIC_LIBS)
+        if (sodium_PKG_STATIC_LIBRARIES)
+            foreach(_libname ${sodium_PKG_STATIC_LIBRARIES})
+                if (NOT _libname MATCHES "^lib.*\\.a$") # ignore strings already ending with .a
+                    list(INSERT sodium_PKG_STATIC_LIBRARIES 0 "lib${_libname}.a")
+                endif()
+            endforeach()
+            list(REMOVE_DUPLICATES sodium_PKG_STATIC_LIBRARIES)
+        else()
+            # if pkgconfig for libsodium doesn't provide
+            # static lib info, then override PKG_STATIC here..
+            set(sodium_PKG_STATIC_LIBRARIES libsodium.a)
+        endif()
+
+        set(XPREFIX sodium_PKG_STATIC)
+    else()
+        if (sodium_PKG_LIBRARIES STREQUAL "")
+            set(sodium_PKG_LIBRARIES sodium)
+        endif()
+
+        set(XPREFIX sodium_PKG)
+    endif()
+
+    find_path(sodium_INCLUDE_DIR sodium.h
+        HINTS ${${XPREFIX}_INCLUDE_DIRS}
+    )
+    find_library(sodium_LIBRARY_DEBUG NAMES ${${XPREFIX}_LIBRARIES}
+        HINTS ${${XPREFIX}_LIBRARY_DIRS}
+    )
+    find_library(sodium_LIBRARY_RELEASE NAMES ${${XPREFIX}_LIBRARIES}
+        HINTS ${${XPREFIX}_LIBRARY_DIRS}
+    )
+
+
+########################################################################
+# Windows
+elseif (WIN32)
+    set(sodium_DIR "$ENV{sodium_DIR}" CACHE FILEPATH "sodium install directory")
+
+    find_path(sodium_INCLUDE_DIR sodium.h
+        HINTS ${sodium_DIR}
+        PATH_SUFFIXES include
+    )
+
+    if (MSVC)
+        # detect target architecture
+        file(WRITE "${CMAKE_CURRENT_BINARY_DIR}/arch.c" [=[
+            #if defined _M_IX86
+            #error ARCH_VALUE x86_32
+            #elif defined _M_X64
+            #error ARCH_VALUE x86_64
+            #endif
+            #error ARCH_VALUE unknown
+        ]=])
+        try_compile(_UNUSED_VAR "${CMAKE_CURRENT_BINARY_DIR}" "${CMAKE_CURRENT_BINARY_DIR}/arch.c"
+            OUTPUT_VARIABLE _COMPILATION_LOG
+        )
+        string(REGEX REPLACE ".*ARCH_VALUE ([a-zA-Z0-9_]+).*" "\\1" _TARGET_ARCH "${_COMPILATION_LOG}")
+
+        # construct library path
+        if (_TARGET_ARCH STREQUAL "x86_32")
+            string(APPEND _PLATFORM_PATH "Win32")
+        elseif(_TARGET_ARCH STREQUAL "x86_64")
+            string(APPEND _PLATFORM_PATH "x64")
+        else()
+            message(FATAL_ERROR "the ${_TARGET_ARCH} architecture is not supported by Findsodium.cmake.")
+        endif()
+        string(APPEND _PLATFORM_PATH "/$$CONFIG$$")
+
+        if (MSVC_VERSION LESS 1900)
+            math(EXPR _VS_VERSION "${MSVC_VERSION} / 10 - 60")
+        else()
+            math(EXPR _VS_VERSION "${MSVC_VERSION} / 10 - 50")
+        endif()
+        string(APPEND _PLATFORM_PATH "/v${_VS_VERSION}")
+
+        if (sodium_USE_STATIC_LIBS)
+            string(APPEND _PLATFORM_PATH "/static")
+        else()
+            string(APPEND _PLATFORM_PATH "/dynamic")
+        endif()
+
+        string(REPLACE "$$CONFIG$$" "Debug" _DEBUG_PATH_SUFFIX "${_PLATFORM_PATH}")
+        string(REPLACE "$$CONFIG$$" "Release" _RELEASE_PATH_SUFFIX "${_PLATFORM_PATH}")
+
+        find_library(sodium_LIBRARY_DEBUG libsodium.lib
+            HINTS ${sodium_DIR}
+            PATH_SUFFIXES ${_DEBUG_PATH_SUFFIX}
+        )
+        find_library(sodium_LIBRARY_RELEASE libsodium.lib
+            HINTS ${sodium_DIR}
+            PATH_SUFFIXES ${_RELEASE_PATH_SUFFIX}
+        )
+        if (NOT sodium_USE_STATIC_LIBS)
+            set(CMAKE_FIND_LIBRARY_SUFFIXES_BCK ${CMAKE_FIND_LIBRARY_SUFFIXES})
+            set(CMAKE_FIND_LIBRARY_SUFFIXES ".dll")
+            find_library(sodium_DLL_DEBUG libsodium
+                HINTS ${sodium_DIR}
+                PATH_SUFFIXES ${_DEBUG_PATH_SUFFIX}
+            )
+            find_library(sodium_DLL_RELEASE libsodium
+                HINTS ${sodium_DIR}
+                PATH_SUFFIXES ${_RELEASE_PATH_SUFFIX}
+            )
+            set(CMAKE_FIND_LIBRARY_SUFFIXES ${CMAKE_FIND_LIBRARY_SUFFIXES_BCK})
+        endif()
+
+    elseif(_GCC_COMPATIBLE)
+        if (sodium_USE_STATIC_LIBS)
+            find_library(sodium_LIBRARY_DEBUG libsodium.a
+                HINTS ${sodium_DIR}
+                PATH_SUFFIXES lib
+            )
+            find_library(sodium_LIBRARY_RELEASE libsodium.a
+                HINTS ${sodium_DIR}
+                PATH_SUFFIXES lib
+            )
+        else()
+            find_library(sodium_LIBRARY_DEBUG libsodium.dll.a
+                HINTS ${sodium_DIR}
+                PATH_SUFFIXES lib
+            )
+            find_library(sodium_LIBRARY_RELEASE libsodium.dll.a
+                HINTS ${sodium_DIR}
+                PATH_SUFFIXES lib
+            )
+
+            file(GLOB _DLL
+                LIST_DIRECTORIES false
+                RELATIVE "${sodium_DIR}/bin"
+                "${sodium_DIR}/bin/libsodium*.dll"
+            )
+            find_library(sodium_DLL_DEBUG ${_DLL} libsodium
+                HINTS ${sodium_DIR}
+                PATH_SUFFIXES bin
+            )
+            find_library(sodium_DLL_RELEASE ${_DLL} libsodium
+                HINTS ${sodium_DIR}
+                PATH_SUFFIXES bin
+            )
+        endif()
+    else()
+        message(FATAL_ERROR "this platform is not supported by FindSodium.cmake")
+    endif()
+
+
+########################################################################
+# unsupported
+else()
+    message(FATAL_ERROR "this platform is not supported by FindSodium.cmake")
+endif()
+
+
+########################################################################
+# common stuff
+
+# extract sodium version
+if (sodium_INCLUDE_DIR)
+    set(_VERSION_HEADER "${_INCLUDE_DIR}/sodium/version.h")
+    if (EXISTS _VERSION_HEADER)
+        file(READ "${_VERSION_HEADER}" _VERSION_HEADER_CONTENT)
+        string(REGEX REPLACE ".*#[ \t]*define[ \t]*SODIUM_VERSION_STRING[ \t]*\"([^\n]*)\".*" "\\1"
+            sodium_VERSION "${_VERSION_HEADER_CONTENT}")
+        set(sodium_VERSION "${sodium_VERSION}" PARENT_SCOPE)
+    endif()
+endif()
+
+# communicate results
+include(FindPackageHandleStandardArgs)
+find_package_handle_standard_args(sodium
+    REQUIRED_VARS
+        sodium_LIBRARY_RELEASE
+        sodium_LIBRARY_DEBUG
+        sodium_INCLUDE_DIR
+    VERSION_VAR
+        sodium_VERSION
+)
+
+# mark file paths as advanced
+if (sodium_FOUND)
+    mark_as_advanced(sodium_DIR)
+    mark_as_advanced(sodium_INCLUDE_DIR)
+    mark_as_advanced(sodium_LIBRARY_DEBUG)
+    mark_as_advanced(sodium_LIBRARY_RELEASE)
+    if (WIN32)
+        mark_as_advanced(sodium_DLL_DEBUG)
+        mark_as_advanced(sodium_DLL_RELEASE)
+    endif()
+endif()
+
+# create imported target
+if(sodium_USE_STATIC_LIBS)
+    set(_LIB_TYPE STATIC)
+else()
+    set(_LIB_TYPE SHARED)
+endif()
+add_library(sodium ${_LIB_TYPE} IMPORTED)
+
+set_target_properties(sodium PROPERTIES
+    INTERFACE_INCLUDE_DIRECTORIES "${sodium_INCLUDE_DIR}"
+    IMPORTED_LINK_INTERFACE_LANGUAGES "C"
+)
+
+if (sodium_USE_STATIC_LIBS)
+    set_target_properties(sodium PROPERTIES
+        INTERFACE_COMPILE_DEFINITIONS "SODIUM_STATIC"
+        IMPORTED_LOCATION "${sodium_LIBRARY_RELEASE}"
+        IMPORTED_LOCATION_DEBUG "${sodium_LIBRARY_DEBUG}"
+    )
+else()
+    if (UNIX)
+        set_target_properties(sodium PROPERTIES
+            IMPORTED_LOCATION "${sodium_LIBRARY_RELEASE}"
+            IMPORTED_LOCATION_DEBUG "${sodium_LIBRARY_DEBUG}"
+        )
+    elseif (WIN32)
+        set_target_properties(sodium PROPERTIES
+            IMPORTED_IMPLIB "${sodium_LIBRARY_RELEASE}"
+            IMPORTED_IMPLIB_DEBUG "${sodium_LIBRARY_DEBUG}"
+        )
+        if (NOT (sodium_DLL_DEBUG MATCHES ".*-NOTFOUND"))
+            set_target_properties(sodium PROPERTIES
+                IMPORTED_LOCATION_DEBUG "${sodium_DLL_DEBUG}"
+            )
+        endif()
+        if (NOT (sodium_DLL_RELEASE MATCHES ".*-NOTFOUND"))
+            set_target_properties(sodium PROPERTIES
+                IMPORTED_LOCATION_RELWITHDEBINFO "${sodium_DLL_RELEASE}"
+                IMPORTED_LOCATION_MINSIZEREL "${sodium_DLL_RELEASE}"
+                IMPORTED_LOCATION_RELEASE "${sodium_DLL_RELEASE}"
+            )
+        endif()
+    endif()
+endif()

--- a/examples/Chat/ChatClient.cpp
+++ b/examples/Chat/ChatClient.cpp
@@ -36,8 +36,9 @@ ChatClient::ChatClient(unsigned short port)
     , m_port(port)
     , m_connected(false) {
     m_peer = wirefox::IPeer::Factory::Create();
-    m_peer->Bind(wirefox::SocketProtocol::IPv4, 0); // bind to any port, doesn't matter for client
     m_peer->SetNetworkSimulation(0.1f, 5);
+    m_peer->SetEncryptionEnabled(true);
+    m_peer->Bind(wirefox::SocketProtocol::IPv4, 0); // bind to any port, doesn't matter for client
 
     m_channelChat = m_peer->MakeChannel(wirefox::ChannelMode::ORDERED);
 }
@@ -92,7 +93,7 @@ void ChatClient::Connect(const std::string& host, unsigned short port) {
         return;
     }
 
-    auto attempt = m_peer->Connect(host, port);
+    auto attempt = m_peer->Connect(host, port, SERVER_KEY_PUBLIC);
     switch (attempt) {
     case wirefox::ConnectAttemptResult::OK:
         std::cout << "Hold on..." << std::endl;

--- a/examples/Chat/ChatClient.cpp
+++ b/examples/Chat/ChatClient.cpp
@@ -12,7 +12,9 @@ namespace {
             return "Communication error: incompatible Wirefox version.";
         case wirefox::ConnectResult::INCOMPATIBLE_SECURITY:
             return "Communication error: incompatible security settings.";
-        case wirefox::ConnectResult::INVALID_PASSWORD:
+        case wirefox::ConnectResult::INCORRECT_REMOTE_IDENTITY:
+            return "Communication error: unable to verify server identity.";
+        case wirefox::ConnectResult::INCORRECT_PASSWORD:
             return "The password is incorrect.";
         case wirefox::ConnectResult::NO_FREE_SLOTS:
             return "The server is full.";

--- a/examples/Chat/ChatServer.cpp
+++ b/examples/Chat/ChatServer.cpp
@@ -6,8 +6,10 @@ ChatServer::ChatServer(unsigned short port)
 
     m_peer = wirefox::IPeer::Factory::Create(maxClients);
     m_peer->SetMaximumIncomingPeers(maxClients);
-    m_peer->Bind(wirefox::SocketProtocol::IPv4, port);
     m_peer->SetNetworkSimulation(0.1f, 5);
+    m_peer->SetEncryptionEnabled(true);
+    m_peer->SetEncryptionLocalKeypair(SERVER_KEY_SECRET, SERVER_KEY_PUBLIC);
+    m_peer->Bind(wirefox::SocketProtocol::IPv4, port);
 
     m_channelChat = m_peer->MakeChannel(wirefox::ChannelMode::ORDERED);
 }

--- a/examples/Chat/Shared.h
+++ b/examples/Chat/Shared.h
@@ -22,6 +22,30 @@ public:
 };
 
 
+// These are example encryption keys, hardcoded for convenience.
+// You can generate your own keys by calling peer->GenerateKeypair(), and passing in two memory blocks
+// that are large enough to hold them (peer->GetEncryptionKeyLength()), then save them to a file.
+
+// Pass your keys peer->SetEncryptionLocalKeypair() on the server, then pass the public key to
+// peer->Connect() on the client. The client will refuse to complete the connection if the server
+// then reports a mismatching public key, thus providing resistance against MITM attacks.
+// Obviously, do not ship the server's secret key with the client like in this demo.
+
+// Note that you don't have to do all this in a pure P2P scenario (you can't, because the server's
+// private key must not ship with the client). Just enabling encryption is enough for general purposes;
+// Wirefox will generate keys and deal with everything under the hood, but keep in mind that an adversary
+// could falsify the key exchange, and the only way to prevent that is by having a secure dedi server.
+
+constexpr static unsigned char SERVER_KEY_SECRET[32] = {
+    0xB9, 0x8D, 0xB6, 0x97, 0x0B, 0x33, 0x78, 0xB3, 0xD4, 0xBE, 0x70, 0x2B, 0xC0, 0x3B, 0x63, 0xB5,
+    0x3C, 0x29, 0xA0, 0xFA, 0xA7, 0x21, 0x8F, 0x59, 0x4D, 0xA4, 0x02, 0xBB, 0xF2, 0xEA, 0x52, 0xCA
+};
+constexpr static unsigned char SERVER_KEY_PUBLIC[32] = {
+    0x1B, 0xB1, 0x24, 0x3B, 0x00, 0xE8, 0x60, 0x94, 0xB9, 0x7E, 0x3B, 0xFF, 0x2D, 0x84, 0x7B, 0x49,
+    0x50, 0xE1, 0x33, 0x74, 0xAC, 0x1B, 0x47, 0x84, 0x1D, 0x1D, 0xFE, 0xB7, 0xDE, 0x6F, 0xAB, 0x2C
+};
+
+
 // https://stackoverflow.com/questions/216823/whats-the-best-way-to-trim-stdstring
 // trim from start (in place)
 inline void ltrim(std::string& s) {

--- a/include/wirefox/BinaryStream.h
+++ b/include/wirefox/BinaryStream.h
@@ -114,6 +114,9 @@ namespace wirefox {
         /// Gets the internal buffer.
         const uint8_t*  GetBuffer() const noexcept { return m_buffer_ro; }
 
+        /// Gets the internal buffer. Use this at your own peril.
+        uint8_t*        GetWritableBuffer() const noexcept { return m_buffer; }
+
         /**
          * \brief Yield ownership of the internal buffer.
          * 
@@ -199,6 +202,16 @@ namespace wirefox {
          * \param[in]   other   The BinaryStream whose contents to copy.
          */
         void            WriteBytes(const BinaryStream& other);
+
+        /**
+         * \brief Write a series of zero bytes to the stream.
+         * 
+         * This is meant for advanced / internal use cases, where a BinaryStream is used to preallocate a chunk of memory,
+         * which is directly written to by another object.
+         * 
+         * \param[in]   len     The number of zero bytes to write.
+         */
+        void            WriteZeroes(size_t len);
 
         /**
          * \brief Writes an array of bytes to the stream.

--- a/include/wirefox/Enumerations.h
+++ b/include/wirefox/Enumerations.h
@@ -23,11 +23,11 @@ namespace wirefox {
         /// The connection attempt was initiated successfully.
         /// \note This does not imply that the connection was actually opened, only that the \a attempt was started.
         OK,
-        /// Invalid settings were passed to Socket::Connect(). The host-name must be non-empty, and the port must be non-zero.
+        /// Invalid settings were specified. Hostname must be non-empty, port must be non-zero, and explicit public key requires enabling crypto.
         INVALID_PARAMETER,
         /// The resolver could not resolve the host name into an endpoint.
         INVALID_HOSTNAME,
-        /// The socket was not ready to begin a connection. For UDP, the socket must be bound to a local port first.
+        /// The socket was not ready to begin a connection. Make sure it is successfully bound to a port.
         INVALID_STATE,
         /// You are already trying to connect to this endpoint. Wait for a NOTIFY_CONNECT_* notification.
         ALREADY_CONNECTING,
@@ -51,8 +51,10 @@ namespace wirefox {
         INCOMPATIBLE_VERSION,
         /// The remote endpoint has different security settings than we do.
         INCOMPATIBLE_SECURITY,
+        /// The identity of the remote endpoint could not be verified because the public key mismatched. Likely causes are a configuration error, or a MITM-attack.
+        INCORRECT_REMOTE_IDENTITY,
         /// The remote endpoint rejected the password.
-        INVALID_PASSWORD,
+        INCORRECT_PASSWORD,
         /// The remote endpoint has no free slots left to connect with us (or does not accept any connections at all). Try again later.
         NO_FREE_SLOTS,
         /// The remote endpoint is already connected with us (or with someone else with the same PeerID).

--- a/include/wirefox/Enumerations.h
+++ b/include/wirefox/Enumerations.h
@@ -49,9 +49,9 @@ namespace wirefox {
         INCOMPATIBLE_PROTOCOL,
         /// The remote endpoint is not running the same version of Wirefox.
         INCOMPATIBLE_VERSION,
-        /// The remote endpoint has different security settings than we do.
+        /// The remote endpoint has different security settings than we do, or an error occurred during encryption or decryption.
         INCOMPATIBLE_SECURITY,
-        /// The identity of the remote endpoint could not be verified because the public key mismatched. Likely causes are a configuration error, or a MITM-attack.
+        /// The identity of the remote endpoint could not be verified. Likely causes are a configuration error, or an active MITM-attack.
         INCORRECT_REMOTE_IDENTITY,
         /// The remote endpoint rejected the password.
         INCORRECT_PASSWORD,

--- a/include/wirefox/PeerAbstract.h
+++ b/include/wirefox/PeerAbstract.h
@@ -213,7 +213,7 @@ namespace wirefox {
         virtual void                    SetEncryptionEnabled(bool enabled) = 0;
 
         /**
-         * \brief Restore a keypair that was previously generated using GenerateKeypair().
+         * \brief Restore a keypair that was previously generated using GenerateIdentity().
          * 
          * Normally, you do not need to use this function. When you enable encryption, a random keypair will be
          * automatically generated for you. This method is meant only to be used for dedicated servers you control.
@@ -221,7 +221,7 @@ namespace wirefox {
          * \param[in]   key_secret      A pointer to the private key.
          * \param[in]   key_public      A pointer to the public key.
          */
-        virtual void                    SetEncryptionLocalKeypair(const uint8_t* key_secret, const uint8_t* key_public) = 0;
+        virtual void                    SetEncryptionIdentity(const uint8_t* key_secret, const uint8_t* key_public) = 0;
 
         /**
          * \brief Generate a keypair, which you can store for later use.
@@ -234,7 +234,7 @@ namespace wirefox {
          * \param[out]  key_secret      Output array to contain the private key.
          * \param[out]  key_public      Output array to contain the public key.
          */
-        virtual void                    GenerateKeypair(uint8_t* key_secret, uint8_t* key_public) const = 0;
+        virtual void                    GenerateIdentity(uint8_t* key_secret, uint8_t* key_public) const = 0;
 
         /**
          * \brief Gets the expected length of all encryption keys, in bytes.

--- a/include/wirefox/PeerAbstract.h
+++ b/include/wirefox/PeerAbstract.h
@@ -66,8 +66,9 @@ namespace wirefox {
          * 
          * \param[in]   host    A hostname, domain name, or IP address, you wish to connect to.
          * \param[in]   port    The port on which to connect. The remote host must be listening on this port.
+         * \param[in]   public_key  The expected public key of the remote end. Set to nullptr if this is unknown.
          */
-        virtual ConnectAttemptResult    Connect(const std::string& host, uint16_t port) = 0;
+        virtual ConnectAttemptResult    Connect(const std::string& host, uint16_t port, const uint8_t* public_key = nullptr) = 0;
 
         /**
          * \brief Bind this peer to a local network interface.
@@ -200,6 +201,45 @@ namespace wirefox {
          * \param[in]   port        The port on which the remote endpoints are expected to listen.
          */
         virtual void                    PingLocalNetwork(uint16_t port) const = 0;
+
+        /**
+         * \brief Sets whether connection encryption is enabled.
+         * 
+         * This must be set \b before Bind() is called. If this peer is already bound, this function does nothing.
+         * Encryption is disabled by default, unless this is called with \p enabled set to true.
+         * 
+         * \param[in]   enabled     Whether to enable or disable cryptography.
+         */
+        virtual void                    SetEncryptionEnabled(bool enabled) = 0;
+
+        /**
+         * \brief Restore a keypair that was previously generated using GenerateKeypair().
+         * 
+         * Normally, you do not need to use this function. When you enable encryption, a random keypair will be
+         * automatically generated for you. This method is meant only to be used for dedicated servers you control.
+         * 
+         * \param[in]   key_secret      A pointer to the private key.
+         * \param[in]   key_public      A pointer to the public key.
+         */
+        virtual void                    SetEncryptionLocalKeypair(const uint8_t* key_secret, const uint8_t* key_public) = 0;
+
+        /**
+         * \brief Generate a keypair, which you can store for later use.
+         * 
+         * You do not need to call this, unless you're hosting a dedicated server whose public key will be shipped
+         * together with the clients. In such a case, use this function to generate that persistent keypair.
+         * 
+         * Both pointers must reference a block of memory that is at least GetEncryptionKeyLength() bytes long.
+         * 
+         * \param[out]  key_secret      Output array to contain the private key.
+         * \param[out]  key_public      Output array to contain the public key.
+         */
+        virtual void                    GenerateKeypair(uint8_t* key_secret, uint8_t* key_public) const = 0;
+
+        /**
+         * \brief Gets the expected length of all encryption keys, in bytes.
+         */
+        virtual size_t                  GetEncryptionKeyLength() const = 0;
 
         /**
          * \brief Registers and returns a new Channel for your packets.

--- a/include/wirefox/WirefoxConfig.h
+++ b/include/wirefox/WirefoxConfig.h
@@ -20,6 +20,8 @@ namespace wirefox {
         class CongestionControlWindow;
         class HandshakerThreeWay;
         class SocketUDP;
+        class EncryptionLayerSodium;
+        class EncryptionLayerNull;
     }
 
     /// Represents a unique identifier for a packet. This is used for tracking which packets are associated with which datagrams.
@@ -50,6 +52,14 @@ namespace wirefox {
 
         /// The Handshaker implementation to use. Changing this lets you easily swap out implementations.
         using DefaultCongestionControl = detail::CongestionControlWindow;
+
+#ifdef WIREFOX_ENABLE_ENCRYPTION
+        /// The EncryptionLayer implementation to use. Changing this lets you easily swap out implementations.
+        using DefaultEncryption = detail::EncryptionLayerSodium;
+#else
+        /// The EncryptionLayer implementation to use. This is a dummy implementation that does nothing.
+        using DefaultEncryption = detail::EncryptionLayerNull;
+#endif
 
         /// Specifies a header that Handshaker should send (and receive), to confirm that both endpoints are running Wirefox.
         constexpr static uint8_t WIREFOX_MAGIC[] = {'W', 'I', 'R', 'E', 'F', 'O', 'X'};

--- a/source/AuthenticatorSodium.cpp
+++ b/source/AuthenticatorSodium.cpp
@@ -1,0 +1,119 @@
+/*
+ * Wirefox Networking API
+ * (C) Mika Molenkamp, 2019.
+ *
+ * Licensed under the BSD 3-Clause License, see the LICENSE file in the project
+ * root folder for more information.
+ */
+
+#include "PCH.h"
+#include "EncryptionAuthenticator.h"
+#include "WirefoxConfigRefs.h"
+
+using namespace detail;
+
+EncryptionAuthenticator::EncryptionAuthenticator(Handshaker::Origin origin, EncryptionLayer& crypto)
+    : m_crypto(crypto)
+    , m_origin(origin)
+    , m_state(STATE_KEY_EXCHANGE) {}
+
+void EncryptionAuthenticator::Begin(BinaryStream& outstream) {
+    std::cout << "Begin STATE_KEY_EXCHANGE" << std::endl;
+    outstream.WriteByte(STATE_KEY_EXCHANGE);
+    outstream.WriteBytes(m_crypto.GetEphemeralPublicKey());
+    outstream.WriteBool(m_crypto.GetNeedsChallenge());
+    m_state = STATE_KEY_EXCHANGE;
+}
+
+ConnectResult EncryptionAuthenticator::Handle(BinaryStream& instream, BinaryStream& outstream) {
+    // discard auth packets that are currently unexpected (possibly duplicate, or hostile)
+    if (instream.ReadByte() != m_state) {
+        std::cout << "Authenticator state mismatch, origin " << int(m_origin) << std::endl;
+        return ConnectResult::IN_PROGRESS;
+    }
+
+    switch (m_state) {
+    case STATE_KEY_EXCHANGE:
+        return HandleKeyExchange(instream, outstream);
+    case STATE_AUTHENTICATION:
+        return HandleAuth(instream, outstream);
+    default:
+        assert(false);
+        return ConnectResult::INCOMPATIBLE_PROTOCOL;
+    }
+}
+
+ConnectResult EncryptionAuthenticator::HandleKeyExchange(BinaryStream& instream, BinaryStream& outstream) {
+    std::cout << "Handle STATE_KEY_EXCHANGE, origin " << int(m_origin) << std::endl;
+
+    // read out the remote public key into a buffer
+    const auto keylen = cfg::DefaultEncryption::GetKeyLength();
+    BinaryStream remoteKey(keylen);
+    remoteKey.WriteZeroes(keylen);
+    remoteKey.SeekToBegin();
+    instream.ReadBytes(remoteKey.GetWritableBuffer(), keylen);
+
+    // pass the buffer to the crypto layer, so the key exchange can be completed
+    if (!m_crypto.HandleKeyExchange(m_origin, remoteKey))
+        return ConnectResult::INCORRECT_REMOTE_IDENTITY;
+
+    switch (m_origin) {
+    case Handshaker::Origin::SELF:
+        // server just sent us their part of the key xchg, so now move on to auth if that's required
+        if (m_crypto.GetNeedsChallenge()) {
+            // write an auth challenge to the handshaker stream
+            std::cout << "Sending auth challenge" << std::endl;
+            outstream.WriteByte(STATE_AUTHENTICATION);
+            m_crypto.CreateChallenge(outstream);
+            m_state = STATE_AUTHENTICATION;
+        } else {
+            // no auth required
+            m_state = STATE_DONE;
+        }
+
+        break;
+    case Handshaker::Origin::REMOTE:
+        // give the client our ephemeral public key, for the key xchg
+        outstream.WriteByte(STATE_KEY_EXCHANGE);
+        outstream.WriteBytes(m_crypto.GetEphemeralPublicKey());
+
+        // client indicates whether they also want to send us an auth challenge
+        if (instream.ReadBool()) {
+            std::cout << "Client desires auth challenge" << std::endl;
+            m_state = STATE_AUTHENTICATION;
+        } else {
+            std::cout << "Client needs no auth challenge" << std::endl;
+            m_state = STATE_DONE;
+            return ConnectResult::OK;
+        }
+
+        break;
+    default:
+        assert(false);
+        break;
+    }
+
+    return ConnectResult::IN_PROGRESS;
+}
+
+ConnectResult EncryptionAuthenticator::HandleAuth(BinaryStream& instream, BinaryStream& outstream) {
+    std::cout << "Handle STATE_AUTHENTICATION, origin " << int(m_origin) << std::endl;
+
+    if (m_origin == Handshaker::Origin::REMOTE) {
+        // incoming challenge, solve it
+        std::cout << "Incoming auth challenge, resolving..." << std::endl;
+        if (!m_crypto.HandleChallengeIncoming(instream, outstream))
+            return ConnectResult::INCOMPATIBLE_SECURITY;
+
+    } else {
+        // challenge response, verify it
+        std::cout << "Incoming auth response, verifying..." << std::endl;
+        auto result = m_crypto.HandleChallengeResponse(instream);
+        if (!result)
+            return ConnectResult::INCORRECT_REMOTE_IDENTITY;
+    }
+
+    // all good!
+    m_state = STATE_DONE;
+    return ConnectResult::OK;
+}

--- a/source/AuthenticatorSodium.h
+++ b/source/AuthenticatorSodium.h
@@ -1,0 +1,46 @@
+/*
+ * Wirefox Networking API
+ * (C) Mika Molenkamp, 2019.
+ *
+ * Licensed under the BSD 3-Clause License, see the LICENSE file in the project
+ * root folder for more information.
+ */
+
+#pragma once
+#include "BinaryStream.h"
+#include "EncryptionLayer.h"
+
+namespace wirefox {
+
+    namespace detail {
+
+        class EncryptionAuthenticator {
+        public:
+            EncryptionAuthenticator(Handshaker::Origin origin, EncryptionLayer& crypto);
+            EncryptionAuthenticator(const EncryptionAuthenticator&) = delete;
+            EncryptionAuthenticator(EncryptionAuthenticator&&) = delete;
+            ~EncryptionAuthenticator() = default;
+
+            EncryptionAuthenticator& operator=(const EncryptionAuthenticator&) = delete;
+            EncryptionAuthenticator& operator=(EncryptionAuthenticator&&) = delete;
+
+            void Begin(BinaryStream& outstream);
+            ConnectResult Handle(BinaryStream& instream, BinaryStream& outstream);
+
+        private:
+            ConnectResult HandleKeyExchange(BinaryStream& instream, BinaryStream& outstream);
+            ConnectResult HandleAuth(BinaryStream& instream, BinaryStream& outstream);
+
+            EncryptionLayer& m_crypto;
+            Handshaker::Origin m_origin;
+
+            enum {
+                STATE_KEY_EXCHANGE,
+                STATE_AUTHENTICATION,
+                STATE_DONE
+            } m_state;
+        };
+
+    }
+
+}

--- a/source/BinaryStream.cpp
+++ b/source/BinaryStream.cpp
@@ -194,8 +194,8 @@ void BinaryStream::Write(ISerializable& obj) {
 
 void BinaryStream::WriteByte(const uint8_t val) {
     if (m_readonly) return;
-    Ensure(1);
     Align();
+    Ensure(1);
     m_buffer[m_position++] = val;
     m_length = std::max(m_length, m_position);
 }
@@ -204,10 +204,19 @@ void BinaryStream::WriteBytes(const BinaryStream& other) {
     WriteBytes(other.m_buffer_ro, other.m_length);
 }
 
+void BinaryStream::WriteZeroes(size_t len) {
+    if (m_readonly) return;
+    Align();
+    Ensure(len);
+    memset(m_buffer + m_position, 0, len);
+    m_position += len;
+    m_length = std::max(m_length, m_position);
+}
+
 void BinaryStream::WriteBytes(const void* addr, const size_t len) {
     if (m_readonly) return;
-    Ensure(len);
     Align();
+    Ensure(len);
     memcpy(m_buffer + m_position, addr, len);
     m_position += len;
     m_length = std::max(m_length, m_position);

--- a/source/BinaryStream.cpp
+++ b/source/BinaryStream.cpp
@@ -163,14 +163,15 @@ void BinaryStream::Clear() {
 }
 
 std::unique_ptr<uint8_t[]> BinaryStream::ToArray() const {
-    auto ret = std::unique_ptr<uint8_t[]>(new uint8_t[m_length]);
     const auto bufferlen = m_length * sizeof(decltype(*m_buffer));
+    auto ret = std::unique_ptr<uint8_t[]>(new uint8_t[bufferlen]);
     memcpy(ret.get(), m_buffer, bufferlen);
     return ret;
 }
 
 std::unique_ptr<uint8_t[]> BinaryStream::ReleaseBuffer(size_t* length) noexcept {
     if (m_readonly) return nullptr;
+    Align();
 
     // fill in length output if specified
     if (length)
@@ -280,6 +281,9 @@ void BinaryStream::WriteBool(bool val) {
         m_position++;
         m_subBytePosition = 0;
         m_length = std::max(m_length, m_position);
+
+    } else {
+        m_length = std::max(m_length, m_position + 1);
     }
 }
 

--- a/source/CMakeLists.txt
+++ b/source/CMakeLists.txt
@@ -16,6 +16,9 @@ target_sources(Wirefox
     ${thisfolder}/DatagramBuilder.h
     ${thisfolder}/DatagramHeader.cpp
     ${thisfolder}/DatagramHeader.h
+    ${thisfolder}/EncryptionLayer.h
+    ${thisfolder}/EncryptionLayerSodium.cpp
+    ${thisfolder}/EncryptionLayerSodium.h
     ${thisfolder}/Handshaker.cpp
     ${thisfolder}/Handshaker.h
     ${thisfolder}/HandshakerThreeWay.cpp

--- a/source/CMakeLists.txt
+++ b/source/CMakeLists.txt
@@ -17,6 +17,7 @@ target_sources(Wirefox
     ${thisfolder}/DatagramHeader.cpp
     ${thisfolder}/DatagramHeader.h
     ${thisfolder}/EncryptionLayer.h
+    ${thisfolder}/EncryptionLayerNull.h
     ${thisfolder}/EncryptionLayerSodium.cpp
     ${thisfolder}/EncryptionLayerSodium.h
     ${thisfolder}/Handshaker.cpp

--- a/source/CMakeLists.txt
+++ b/source/CMakeLists.txt
@@ -16,6 +16,8 @@ target_sources(Wirefox
     ${thisfolder}/DatagramBuilder.h
     ${thisfolder}/DatagramHeader.cpp
     ${thisfolder}/DatagramHeader.h
+    ${thisfolder}/EncryptionAuthenticator.cpp
+    ${thisfolder}/EncryptionAuthenticator.h
     ${thisfolder}/EncryptionLayer.h
     ${thisfolder}/EncryptionLayerNull.h
     ${thisfolder}/EncryptionLayerSodium.cpp

--- a/source/DatagramBuilder.cpp
+++ b/source/DatagramBuilder.cpp
@@ -112,7 +112,7 @@ PacketQueue::OutgoingDatagram* DatagramBuilder::MakeDatagram(RemotePeer& remote,
     PacketQueue::OutgoingDatagram datagram;
     datagram.id = remote.congestion->GetNextDatagramID();
     datagram.addr = sendQueue[0]->addr; // TODO: is this ok?
-    datagram.forceCrypto = sendQueue[0]->forceCrypto; // should only ever be set for some OOB packets
+    datagram.crypto = sendQueue[0]->crypto; // should only ever be set for some OOB packets
     datagram.discard = Time::Now() + Time::FromSeconds(5);
 
     DatagramHeader header;
@@ -168,7 +168,7 @@ PacketQueue::OutgoingDatagram* DatagramBuilder::MakeAckgram(RemotePeer& remote) 
     ackgram.addr = remote.addr;
     ackgram.id = remote.congestion->GetNextDatagramID();
     ackgram.discard = Time::Now() + Time::FromSeconds(1);
-    ackgram.forceCrypto = nullptr;
+    ackgram.crypto = nullptr;
 
     // build and write a datagram containing these acks
     DatagramHeader header;

--- a/source/DatagramBuilder.cpp
+++ b/source/DatagramBuilder.cpp
@@ -112,6 +112,7 @@ PacketQueue::OutgoingDatagram* DatagramBuilder::MakeDatagram(RemotePeer& remote,
     PacketQueue::OutgoingDatagram datagram;
     datagram.id = remote.congestion->GetNextDatagramID();
     datagram.addr = sendQueue[0]->addr; // TODO: is this ok?
+    datagram.forceCrypto = sendQueue[0]->forceCrypto; // should only ever be set for some OOB packets
     datagram.discard = Time::Now() + Time::FromSeconds(5);
 
     DatagramHeader header;
@@ -167,6 +168,7 @@ PacketQueue::OutgoingDatagram* DatagramBuilder::MakeAckgram(RemotePeer& remote) 
     ackgram.addr = remote.addr;
     ackgram.id = remote.congestion->GetNextDatagramID();
     ackgram.discard = Time::Now() + Time::FromSeconds(1);
+    ackgram.forceCrypto = nullptr;
 
     // build and write a datagram containing these acks
     DatagramHeader header;

--- a/source/EncryptionAuthenticator.cpp
+++ b/source/EncryptionAuthenticator.cpp
@@ -1,0 +1,128 @@
+/*
+ * Wirefox Networking API
+ * (C) Mika Molenkamp, 2019.
+ *
+ * Licensed under the BSD 3-Clause License, see the LICENSE file in the project
+ * root folder for more information.
+ */
+
+#include "PCH.h"
+#include "EncryptionAuthenticator.h"
+#include "WirefoxConfigRefs.h"
+
+using namespace detail;
+
+EncryptionAuthenticator::EncryptionAuthenticator(Handshaker::Origin origin, EncryptionLayer& crypto)
+    : m_crypto(crypto)
+    , m_origin(origin)
+    , m_state(STATE_KEY_EXCHANGE) {}
+
+void EncryptionAuthenticator::Begin(BinaryStream& outstream) {
+    std::cout << "Begin STATE_KEY_EXCHANGE" << std::endl;
+    outstream.WriteByte(STATE_KEY_EXCHANGE);
+    outstream.WriteBytes(m_crypto.GetEphemeralPublicKey());
+    outstream.WriteBool(m_crypto.GetNeedsChallenge());
+    m_state = STATE_KEY_EXCHANGE;
+}
+
+ConnectResult EncryptionAuthenticator::Handle(BinaryStream& instream, BinaryStream& outstream) {
+    // discard auth packets that are currently unexpected (possibly duplicate, or hostile)
+    if (instream.ReadByte() != m_state) {
+        std::cout << "Authenticator state mismatch, origin " << int(m_origin) << std::endl;
+        return ConnectResult::IN_PROGRESS;
+    }
+
+    switch (m_state) {
+    case STATE_KEY_EXCHANGE:
+        return HandleKeyExchange(instream, outstream);
+    case STATE_AUTHENTICATION:
+        return HandleAuth(instream, outstream);
+    case STATE_DONE:
+        assert(m_origin == Handshaker::Origin::REMOTE);
+        return ConnectResult::OK;
+    default:
+        assert(false && "corrupt AUTH_MSG passed to EncryptionAuthenticator");
+        return ConnectResult::INCOMPATIBLE_PROTOCOL;
+    }
+}
+
+ConnectResult EncryptionAuthenticator::HandleKeyExchange(BinaryStream& instream, BinaryStream& outstream) {
+    std::cout << "Handle STATE_KEY_EXCHANGE, origin " << int(m_origin) << std::endl;
+
+    // read out the remote public key into a buffer
+    const auto keylen = cfg::DefaultEncryption::GetKeyLength();
+    BinaryStream remoteKey(keylen);
+    remoteKey.WriteZeroes(keylen);
+    remoteKey.SeekToBegin();
+    instream.ReadBytes(remoteKey.GetWritableBuffer(), keylen);
+
+    // pass the buffer to the crypto layer, so the key exchange can be completed
+    if (!m_crypto.HandleKeyExchange(m_origin, remoteKey))
+        return ConnectResult::INCORRECT_REMOTE_IDENTITY;
+
+    switch (m_origin) {
+    case Handshaker::Origin::SELF:
+        // server just sent us their part of the key xchg, so now move on to auth if that's required
+        if (m_crypto.GetNeedsChallenge()) {
+            // write an auth challenge to the handshaker stream
+            std::cout << "Sending auth challenge" << std::endl;
+            outstream.WriteByte(STATE_AUTHENTICATION);
+            m_crypto.CreateChallenge(outstream);
+            m_state = STATE_AUTHENTICATION;
+        } else {
+            // no auth required, send final ack
+            m_state = STATE_DONE;
+            outstream.WriteByte(STATE_DONE);
+            return ConnectResult::OK;
+        }
+
+        break;
+    case Handshaker::Origin::REMOTE:
+        // give the client our ephemeral public key, for the key xchg
+        outstream.WriteByte(STATE_KEY_EXCHANGE);
+        outstream.WriteBytes(m_crypto.GetEphemeralPublicKey());
+
+        // client indicates whether they also want to send us an auth challenge
+        if (instream.ReadBool()) {
+            std::cout << "Client desires auth challenge" << std::endl;
+            m_state = STATE_AUTHENTICATION;
+        } else {
+            std::cout << "Client needs no auth challenge" << std::endl;
+            m_state = STATE_DONE;
+            return ConnectResult::OK;
+        }
+
+        break;
+    default:
+        assert(false);
+        break;
+    }
+
+    return ConnectResult::IN_PROGRESS;
+}
+
+ConnectResult EncryptionAuthenticator::HandleAuth(BinaryStream& instream, BinaryStream& outstream) {
+    std::cout << "Handle STATE_AUTHENTICATION, origin " << int(m_origin) << std::endl;
+
+    if (m_origin == Handshaker::Origin::REMOTE) {
+        // incoming challenge, solve it
+        std::cout << "Incoming auth challenge, solving..." << std::endl;
+        outstream.WriteByte(STATE_AUTHENTICATION);
+        if (!m_crypto.HandleChallengeIncoming(instream, outstream))
+            return ConnectResult::INCOMPATIBLE_SECURITY;
+
+        return ConnectResult::IN_PROGRESS;
+
+    } else {
+        // challenge response, verify it
+        std::cout << "Incoming auth response, verifying..." << std::endl;
+        auto result = m_crypto.HandleChallengeResponse(instream);
+        if (!result)
+            return ConnectResult::INCORRECT_REMOTE_IDENTITY;
+
+        // all good! send final ack
+        m_state = STATE_DONE;
+        outstream.WriteByte(STATE_DONE);
+        return ConnectResult::OK;
+    }
+}

--- a/source/EncryptionAuthenticator.h
+++ b/source/EncryptionAuthenticator.h
@@ -1,0 +1,46 @@
+/*
+ * Wirefox Networking API
+ * (C) Mika Molenkamp, 2019.
+ *
+ * Licensed under the BSD 3-Clause License, see the LICENSE file in the project
+ * root folder for more information.
+ */
+
+#pragma once
+#include "BinaryStream.h"
+#include "EncryptionLayer.h"
+
+namespace wirefox {
+
+    namespace detail {
+
+        class EncryptionAuthenticator {
+        public:
+            EncryptionAuthenticator(Handshaker::Origin origin, EncryptionLayer& crypto);
+            EncryptionAuthenticator(const EncryptionAuthenticator&) = delete;
+            EncryptionAuthenticator(EncryptionAuthenticator&&) = delete;
+            ~EncryptionAuthenticator() = default;
+
+            EncryptionAuthenticator& operator=(const EncryptionAuthenticator&) = delete;
+            EncryptionAuthenticator& operator=(EncryptionAuthenticator&&) = delete;
+
+            void Begin(BinaryStream& outstream);
+            ConnectResult Handle(BinaryStream& instream, BinaryStream& outstream);
+
+        private:
+            ConnectResult HandleKeyExchange(BinaryStream& instream, BinaryStream& outstream);
+            ConnectResult HandleAuth(BinaryStream& instream, BinaryStream& outstream);
+
+            EncryptionLayer& m_crypto;
+            Handshaker::Origin m_origin;
+
+            enum {
+                STATE_KEY_EXCHANGE,
+                STATE_AUTHENTICATION,
+                STATE_DONE
+            } m_state;
+        };
+
+    }
+
+}

--- a/source/EncryptionAuthenticator.h
+++ b/source/EncryptionAuthenticator.h
@@ -26,6 +26,7 @@ namespace wirefox {
 
             void Begin(BinaryStream& outstream);
             ConnectResult Handle(BinaryStream& instream, BinaryStream& outstream);
+            void PostHandle();
 
         private:
             ConnectResult HandleKeyExchange(BinaryStream& instream, BinaryStream& outstream);
@@ -39,6 +40,8 @@ namespace wirefox {
                 STATE_AUTHENTICATION,
                 STATE_DONE
             } m_state;
+
+            bool m_enableCryptoAfterReply;
         };
 
     }

--- a/source/EncryptionLayer.h
+++ b/source/EncryptionLayer.h
@@ -1,0 +1,97 @@
+/**
+ * Wirefox Networking API
+ * (C) Mika Molenkamp, 2019.
+ *
+ * Licensed under the BSD 3-Clause License, see the LICENSE file in the project
+ * root folder for more information.
+ */
+
+#pragma once
+#include "BinaryStream.h"
+#include "Handshaker.h"
+
+namespace wirefox {
+
+    namespace detail {
+
+        /**
+         * \cond WIREFOX_INTERNAL
+         * \brief Represents an abstract encryption mechanism.
+         * 
+         * The purpose of this interface is to provide a wrapper using Wirefox objects around any
+         * implementation, and to avoid leaking any and all implementation details.
+         * 
+         * This interface makes no assumptions about the underlying cryptography, other than that
+         * a key exchange takes place before any data is sent.
+         */
+        class EncryptionLayer {
+        public:
+            /// Default constructor
+            EncryptionLayer() = default;
+            /// Copy constructor
+            EncryptionLayer(const EncryptionLayer&) = delete;
+            /// Move constructor
+            EncryptionLayer(EncryptionLayer&&) noexcept = default;
+            /// Destructor
+            virtual ~EncryptionLayer() = default;
+
+            /// Copy assignment operator
+            EncryptionLayer& operator=(const EncryptionLayer&) = delete;
+            /// Move assignment operator
+            EncryptionLayer& operator=(EncryptionLayer&&) noexcept = default;
+
+            /**
+             * \brief Returns a value indicating whether an error has occurred.
+             * 
+             * If a cryptographic operation fails, or if a verification operation fails, or if the
+             * implementation believes the connected party is compromised, this function returns true.
+             * 
+             * This should be tested after calling SetRemotePublicKey(), Encrypt(), or Decrypt().
+             */
+            virtual bool GetNeedsToBail() const = 0;
+
+            /**
+             * \brief Returns the maximum amount of overhead added to a plaintext, in bytes.
+             */
+            virtual size_t GetOverhead() const = 0;
+
+            /**
+             * \brief Returns a key belonging to this peer for use in key exchange algorithms.
+             * 
+             * As part of a key exchange, this piece of data should be sent to the other party.
+             */
+            virtual BinaryStream GetPublicKey() const = 0;
+
+            /**
+             * \brief Completes the key exchange using a remote public key.
+             * 
+             * As part of a key exchange, this function should be called to compute and store session keys
+             * before any data is encrypted or decrypted.
+             * 
+             * \param[in]   origin      Specifies which endpoint initiated the connection.
+             * \param[in]   pubkey      The public key of the remote endpoint.
+             */
+            virtual void SetRemotePublicKey(Handshaker::Origin origin, BinaryStream& pubkey) = 0;
+
+            /**
+             * \brief Encrypts a piece of data into a ciphertext.
+             * 
+             * \param[in]   plaintext   The message that should be encrypted.
+             * \returns An opaque blob representing the ciphertext. May be longer than \p plaintext, if needed.
+             */
+            virtual BinaryStream Encrypt(const BinaryStream& plaintext) = 0;
+
+            /**
+             * \brief Decrypts a ciphertext into a plaintext.
+             * 
+             * \param[in]   ciphertext  The encrypted data, as received from the remote party.
+             * \returns The decrypted plaintext, on success. On failure, return value is undefined.
+             */
+            virtual BinaryStream Decrypt(BinaryStream& ciphertext) = 0;
+        };
+
+        /// \endcond
+
+    }
+
+}

--- a/source/EncryptionLayer.h
+++ b/source/EncryptionLayer.h
@@ -26,6 +26,12 @@ namespace wirefox {
          */
         class EncryptionLayer {
         public:
+            /// Represents an abstract public/private keypair.
+            class Keypair {
+            protected:
+                Keypair() = default;
+            };
+
             /// Default constructor
             EncryptionLayer() = default;
             /// Copy constructor
@@ -51,11 +57,6 @@ namespace wirefox {
             virtual bool GetNeedsToBail() const = 0;
 
             /**
-             * \brief Returns the maximum amount of overhead added to a plaintext, in bytes.
-             */
-            virtual size_t GetOverhead() const = 0;
-
-            /**
              * \brief Returns a key belonging to this peer for use in key exchange algorithms.
              * 
              * As part of a key exchange, this piece of data should be sent to the other party.
@@ -72,6 +73,8 @@ namespace wirefox {
              * \param[in]   pubkey      The public key of the remote endpoint.
              */
             virtual void SetRemotePublicKey(Handshaker::Origin origin, BinaryStream& pubkey) = 0;
+
+            virtual void SetLocalKeypair(std::shared_ptr<Keypair> keypair) = 0;
 
             /**
              * \brief Encrypts a piece of data into a ciphertext.

--- a/source/EncryptionLayer.h
+++ b/source/EncryptionLayer.h
@@ -52,7 +52,7 @@ namespace wirefox {
              * If a cryptographic operation fails, or if a verification operation fails, or if the
              * implementation believes the connected party is compromised, this function returns true.
              * 
-             * This should be tested after calling SetRemotePublicKey(), Encrypt(), or Decrypt().
+             * This should be tested after calling HandleKeyExchange(), Encrypt(), or Decrypt().
              */
             virtual bool GetNeedsToBail() const = 0;
 
@@ -61,7 +61,15 @@ namespace wirefox {
              * 
              * As part of a key exchange, this piece of data should be sent to the other party.
              */
-            virtual BinaryStream GetPublicKey() const = 0;
+            virtual BinaryStream GetEphemeralPublicKey() const = 0;
+
+            virtual void SetCryptoEstablished() = 0;
+            virtual bool GetCryptoEstablished() const = 0;
+            virtual bool GetNeedsChallenge() const = 0;
+
+            virtual void CreateChallenge(BinaryStream& outstream) = 0;
+            virtual bool HandleChallengeIncoming(BinaryStream& instream, BinaryStream& answer) = 0;
+            virtual bool HandleChallengeResponse(BinaryStream& instream) = 0;
 
             /**
              * \brief Completes the key exchange using a remote public key.
@@ -73,16 +81,16 @@ namespace wirefox {
              * \param[in]   pubkey      The public key of the remote endpoint.
              * 
              * \returns False if the key is incorrect/suspicious, e.g. if it mismatches the key set by
-             * ExpectRemotePublicKey(). Otherwise, returns true.
+             * ExpectRemoteIdentity(). Otherwise, returns true.
              */
-            virtual bool SetRemotePublicKey(Handshaker::Origin origin, BinaryStream& pubkey) = 0;
+            virtual bool HandleKeyExchange(Handshaker::Origin origin, BinaryStream& pubkey) = 0;
 
             /**
              * \brief Sets the keypair that represents the local peer.
              * 
              * \param[in]   keypair     A reference to the keypair shared by all remotes on this local peer.
              */
-            virtual void SetLocalKeypair(std::shared_ptr<Keypair> keypair) = 0;
+            virtual void SetLocalIdentity(std::shared_ptr<Keypair> keypair) = 0;
 
             /**
              * \brief Informs the crypto layer that this specific public key is expected.
@@ -92,7 +100,7 @@ namespace wirefox {
              * 
              * \param[in]   pubkey      A stream that contains the remote endpoint's public key.
              */
-            virtual void ExpectRemotePublicKey(BinaryStream& pubkey) = 0;
+            virtual void ExpectRemoteIdentity(BinaryStream& pubkey) = 0;
 
             /**
              * \brief Encrypts a piece of data into a ciphertext.

--- a/source/EncryptionLayer.h
+++ b/source/EncryptionLayer.h
@@ -71,10 +71,28 @@ namespace wirefox {
              * 
              * \param[in]   origin      Specifies which endpoint initiated the connection.
              * \param[in]   pubkey      The public key of the remote endpoint.
+             * 
+             * \returns False if the key is incorrect/suspicious, e.g. if it mismatches the key set by
+             * ExpectRemotePublicKey(). Otherwise, returns true.
              */
-            virtual void SetRemotePublicKey(Handshaker::Origin origin, BinaryStream& pubkey) = 0;
+            virtual bool SetRemotePublicKey(Handshaker::Origin origin, BinaryStream& pubkey) = 0;
 
+            /**
+             * \brief Sets the keypair that represents the local peer.
+             * 
+             * \param[in]   keypair     A reference to the keypair shared by all remotes on this local peer.
+             */
             virtual void SetLocalKeypair(std::shared_ptr<Keypair> keypair) = 0;
+
+            /**
+             * \brief Informs the crypto layer that this specific public key is expected.
+             * 
+             * This is meant to be used for dedicated server scenarios, where a secure, authorative server can
+             * have a keypair whose public key ships with the client software.
+             * 
+             * \param[in]   pubkey      A stream that contains the remote endpoint's public key.
+             */
+            virtual void ExpectRemotePublicKey(BinaryStream& pubkey) = 0;
 
             /**
              * \brief Encrypts a piece of data into a ciphertext.

--- a/source/EncryptionLayerNull.h
+++ b/source/EncryptionLayerNull.h
@@ -1,0 +1,54 @@
+/**
+ * Wirefox Networking API
+ * (C) Mika Molenkamp, 2019.
+ *
+ * Licensed under the BSD 3-Clause License, see the LICENSE file in the project
+ * root folder for more information.
+ */
+
+#pragma once
+#include "EncryptionLayer.h"
+
+namespace wirefox {
+
+    namespace detail {
+
+        /**
+         * \cond WIREFOX_INTERNAL
+         * \brief Represents a cryptography layer that returns messages unchanged.
+         */
+        class EncryptionLayerNull : public EncryptionLayer {
+        public:
+            EncryptionLayerNull() = default;
+            EncryptionLayerNull(const EncryptionLayerNull&) = delete;
+            EncryptionLayerNull(EncryptionLayerNull&&) noexcept = default;
+            virtual ~EncryptionLayerNull() = default;
+
+            EncryptionLayerNull& operator=(const EncryptionLayerNull&) = delete;
+            EncryptionLayerNull& operator=(EncryptionLayerNull&&) noexcept = default;
+
+            bool GetNeedsToBail() const override { return false; };
+
+            BinaryStream GetPublicKey() const override { return BinaryStream(0); }
+            void SetRemotePublicKey(Handshaker::Origin, BinaryStream&) override {}
+
+            BinaryStream Encrypt(const BinaryStream& plaintext) override { return plaintext; }
+            BinaryStream Decrypt(BinaryStream& ciphertext) override { return ciphertext; }
+            void SetLocalKeypair(std::shared_ptr<Keypair>) override {}
+
+            /**
+             * \brief Returns the maximum amount of overhead added to a plaintext, in bytes.
+             */
+            static size_t GetOverhead() { return 0; }
+
+            /**
+             * \brief Returns the length of the private or public key, in bytes.
+             */
+            static size_t GetKeyLength() { return 0; }
+        };
+
+        /// \endcond
+
+    }
+
+}

--- a/source/EncryptionLayerNull.h
+++ b/source/EncryptionLayerNull.h
@@ -30,7 +30,8 @@ namespace wirefox {
             bool GetNeedsToBail() const override { return false; };
 
             BinaryStream GetPublicKey() const override { return BinaryStream(0); }
-            void SetRemotePublicKey(Handshaker::Origin, BinaryStream&) override {}
+            bool SetRemotePublicKey(Handshaker::Origin, BinaryStream&) override { return true; }
+            void ExpectRemotePublicKey(BinaryStream&) override {}
 
             BinaryStream Encrypt(const BinaryStream& plaintext) override { return plaintext; }
             BinaryStream Decrypt(BinaryStream& ciphertext) override { return ciphertext; }

--- a/source/EncryptionLayerNull.h
+++ b/source/EncryptionLayerNull.h
@@ -29,13 +29,13 @@ namespace wirefox {
 
             bool GetNeedsToBail() const override { return false; };
 
-            BinaryStream GetPublicKey() const override { return BinaryStream(0); }
-            bool SetRemotePublicKey(Handshaker::Origin, BinaryStream&) override { return true; }
-            void ExpectRemotePublicKey(BinaryStream&) override {}
+            BinaryStream GetEphemeralPublicKey() const override { return BinaryStream(0); }
+            bool HandleKeyExchange(Handshaker::Origin, BinaryStream&) override { return true; }
+            void ExpectRemoteIdentity(BinaryStream&) override {}
 
             BinaryStream Encrypt(const BinaryStream& plaintext) override { return plaintext; }
             BinaryStream Decrypt(BinaryStream& ciphertext) override { return ciphertext; }
-            void SetLocalKeypair(std::shared_ptr<Keypair>) override {}
+            void SetLocalIdentity(std::shared_ptr<Keypair>) override {}
 
             /**
              * \brief Returns the maximum amount of overhead added to a plaintext, in bytes.

--- a/source/EncryptionLayerSodium.cpp
+++ b/source/EncryptionLayerSodium.cpp
@@ -107,12 +107,11 @@ BinaryStream EncryptionLayerSodium::Decrypt(BinaryStream& ciphertext) {
     ciphertext.SeekToBegin();
     ciphertext.ReadBytes(nonce, sizeof nonce);
 
+    assert(static_cast<int>(ciphertext.GetLength()) - crypto_secretbox_MACBYTES - crypto_secretbox_NONCEBYTES >= 0);
     const size_t plaintext_len = ciphertext.GetLength() - crypto_secretbox_MACBYTES - crypto_secretbox_NONCEBYTES;
     const size_t ciphertext_len = ciphertext.GetLength() - crypto_secretbox_NONCEBYTES;
-    assert(plaintext_len >= 0);
 
     BinaryStream plaintext = PreallocateBuffer(plaintext_len);
-
     if (crypto_secretbox_open_easy(plaintext.GetWritableBuffer(), ciphertext.GetBuffer() + crypto_secretbox_NONCEBYTES, ciphertext_len, nonce, m_key_rx) != 0)
         m_error = true;
 

--- a/source/EncryptionLayerSodium.cpp
+++ b/source/EncryptionLayerSodium.cpp
@@ -111,8 +111,6 @@ bool EncryptionLayerSodium::SetRemotePublicKey(Handshaker::Origin origin, Binary
         break;
     }
 
-    std::cout << "rx = " << static_cast<int>(m_key_rx[0]) << ", tx = " << static_cast<int>(m_key_tx[0]) << std::endl;
-
     return !m_error;
 }
 

--- a/source/EncryptionLayerSodium.cpp
+++ b/source/EncryptionLayerSodium.cpp
@@ -1,0 +1,123 @@
+#include "PCH.h"
+#include "EncryptionLayerSodium.h"
+
+#ifdef WIREFOX_ENABLE_ENCRYPTION
+#include <sodium.h>
+
+using namespace detail;
+
+namespace {
+    
+    BinaryStream PreallocateBuffer(const size_t len) {
+        BinaryStream buffer(len);
+        buffer.WriteZeroes(len); // advance length counter
+        return buffer;
+    }
+
+}
+
+EncryptionLayerSodium::EncryptionLayerSodium()
+    : m_kx_secret{}
+    , m_kx_public{}
+    , m_key_rx{}
+    , m_key_tx{}
+    , m_error(false) {
+    // asserts done here to make sure the key array sizes match up with what libsodium expects;
+    // I don't want to include sodium.h publically so can't use the macros there directly
+    static_assert(crypto_kx_PUBLICKEYBYTES == KEY_LENGTH, "bad public key array size");
+    static_assert(crypto_kx_SECRETKEYBYTES == KEY_LENGTH, "bad private key array size");
+    static_assert(crypto_kx_SESSIONKEYBYTES == KEY_LENGTH, "bad session key array size");
+
+    if (sodium_init() < 0)
+        throw std::runtime_error("libsodium failed to init");
+
+    crypto_kx_keypair(m_kx_public, m_kx_secret);
+}
+
+EncryptionLayerSodium::EncryptionLayerSodium(EncryptionLayerSodium&&) noexcept
+    : EncryptionLayerSodium() {}
+
+EncryptionLayerSodium::~EncryptionLayerSodium() {
+    // securely erase all keys from memory
+    sodium_memzero(m_kx_secret, KEY_LENGTH);
+    sodium_memzero(m_kx_public, KEY_LENGTH);
+    sodium_memzero(m_key_rx, KEY_LENGTH);
+    sodium_memzero(m_key_tx, KEY_LENGTH);
+}
+
+EncryptionLayerSodium& EncryptionLayerSodium::operator=(EncryptionLayerSodium&&) noexcept {
+    return *this;
+}
+
+bool EncryptionLayerSodium::GetNeedsToBail() const {
+    return m_error;
+}
+
+size_t EncryptionLayerSodium::GetOverhead() const {
+    return crypto_secretbox_MACBYTES + crypto_secretbox_NONCEBYTES;
+}
+
+BinaryStream EncryptionLayerSodium::GetPublicKey() const {
+    BinaryStream ret(KEY_LENGTH);
+    ret.WriteBytes(m_kx_public, KEY_LENGTH);
+    ret.SeekToBegin();
+    return ret;
+}
+
+void EncryptionLayerSodium::SetRemotePublicKey(Handshaker::Origin origin, BinaryStream& pubkey) {
+    uint8_t remotekey[KEY_LENGTH];
+    pubkey.ReadBytes(remotekey, KEY_LENGTH);
+
+    switch (origin) {
+    case Handshaker::Origin::SELF:
+        if (crypto_kx_client_session_keys(m_key_rx, m_key_tx, m_kx_public, m_kx_secret, remotekey) != 0)
+            m_error = true;
+        break;
+    case Handshaker::Origin::REMOTE:
+        if (crypto_kx_server_session_keys(m_key_rx, m_key_tx, m_kx_public, m_kx_secret, remotekey) != 0)
+            m_error = true;
+        break;
+    default:
+        assert(false && "invalid Handshaker::Origin in EncryptionLayerSodium::SetRemotePublicKey");
+        break;
+    }
+}
+
+BinaryStream EncryptionLayerSodium::Encrypt(const BinaryStream& plaintext) {
+    // allocate a buffer long enough to hold the full ciphertext
+    const size_t ciphertext_len_full = plaintext.GetLength() + crypto_secretbox_MACBYTES + crypto_secretbox_NONCEBYTES;
+    BinaryStream ciphertext = PreallocateBuffer(ciphertext_len_full);
+    auto* ciphertext_ptr = ciphertext.GetWritableBuffer() + crypto_secretbox_NONCEBYTES;
+
+    // get a random nonce, and add it to the full ciphertext as prefix
+    uint8_t nonce[crypto_secretbox_NONCEBYTES];
+    randombytes_buf(nonce, sizeof nonce);
+    ciphertext.SeekToBegin();
+    ciphertext.WriteBytes(nonce, sizeof nonce);
+
+    // encrypt the plaintext and write it to the output BinaryStream
+    crypto_secretbox_easy(ciphertext_ptr, plaintext.GetBuffer(), plaintext.GetLength(), nonce, m_key_tx);
+
+    ciphertext.SeekToBegin();
+    return ciphertext;
+}
+
+BinaryStream EncryptionLayerSodium::Decrypt(BinaryStream& ciphertext) {
+    uint8_t nonce[crypto_secretbox_NONCEBYTES];
+    ciphertext.SeekToBegin();
+    ciphertext.ReadBytes(nonce, sizeof nonce);
+
+    const size_t plaintext_len = ciphertext.GetLength() - crypto_secretbox_MACBYTES - crypto_secretbox_NONCEBYTES;
+    const size_t ciphertext_len = ciphertext.GetLength() - crypto_secretbox_NONCEBYTES;
+    assert(plaintext_len >= 0);
+
+    BinaryStream plaintext = PreallocateBuffer(plaintext_len);
+
+    if (crypto_secretbox_open_easy(plaintext.GetWritableBuffer(), ciphertext.GetBuffer() + crypto_secretbox_NONCEBYTES, ciphertext_len, nonce, m_key_rx) != 0)
+        m_error = true;
+
+    plaintext.SeekToBegin();
+    return plaintext;
+}
+
+#endif

--- a/source/EncryptionLayerSodium.cpp
+++ b/source/EncryptionLayerSodium.cpp
@@ -107,7 +107,7 @@ BinaryStream EncryptionLayerSodium::Decrypt(BinaryStream& ciphertext) {
     ciphertext.SeekToBegin();
     ciphertext.ReadBytes(nonce, sizeof nonce);
 
-    assert(static_cast<int>(ciphertext.GetLength()) - crypto_secretbox_MACBYTES - crypto_secretbox_NONCEBYTES >= 0);
+    //assert(static_cast<int>(ciphertext.GetLength()) - crypto_secretbox_MACBYTES - crypto_secretbox_NONCEBYTES >= 0);
     const size_t plaintext_len = ciphertext.GetLength() - crypto_secretbox_MACBYTES - crypto_secretbox_NONCEBYTES;
     const size_t ciphertext_len = ciphertext.GetLength() - crypto_secretbox_NONCEBYTES;
 

--- a/source/EncryptionLayerSodium.cpp
+++ b/source/EncryptionLayerSodium.cpp
@@ -54,8 +54,10 @@ EncryptionLayerSodium::EncryptionLayerSodium()
         throw std::runtime_error("libsodium failed to init");
 }
 
-EncryptionLayerSodium::EncryptionLayerSodium(EncryptionLayerSodium&&) noexcept
-    : EncryptionLayerSodium() {}
+EncryptionLayerSodium::EncryptionLayerSodium(EncryptionLayerSodium&& other) noexcept
+    : EncryptionLayerSodium() {
+    *this = std::move(other);
+}
 
 EncryptionLayerSodium::~EncryptionLayerSodium() {
     // securely erase all keys from memory
@@ -64,7 +66,23 @@ EncryptionLayerSodium::~EncryptionLayerSodium() {
     sodium_memzero(m_key_tx, KEY_LENGTH);
 }
 
-EncryptionLayerSodium& EncryptionLayerSodium::operator=(EncryptionLayerSodium&&) noexcept {
+EncryptionLayerSodium& EncryptionLayerSodium::operator=(EncryptionLayerSodium&& other) noexcept {
+    if (this != &other) {
+        m_kx = std::move(other.m_kx);
+
+        memcpy(m_key_expect_pub, other.m_key_expect_pub, sizeof m_key_expect_pub);
+        memcpy(m_key_rx, other.m_key_rx, sizeof m_key_rx);
+        memcpy(m_key_tx, other.m_key_tx, sizeof m_key_tx);
+
+        sodium_memzero(other.m_key_expect_pub, sizeof m_key_expect_pub);
+        sodium_memzero(other.m_key_rx, sizeof m_key_rx);
+        sodium_memzero(other.m_key_tx, sizeof m_key_tx);
+
+        m_error = other.m_error;
+        m_knowsRemotePubkey = other.m_knowsRemotePubkey;
+        other.m_error = false;
+        other.m_knowsRemotePubkey = false;
+    }
     return *this;
 }
 

--- a/source/EncryptionLayerSodium.cpp
+++ b/source/EncryptionLayerSodium.cpp
@@ -1,8 +1,20 @@
+/*
+ * Wirefox Networking API
+ * (C) Mika Molenkamp, 2019.
+ *
+ * Licensed under the BSD 3-Clause License, see the LICENSE file in the project
+ * root folder for more information.
+ */
+
 #include "PCH.h"
 #include "EncryptionLayerSodium.h"
 
 #ifdef WIREFOX_ENABLE_ENCRYPTION
+#define WIREFOX_SODIUM_MONITORING 1
 #include <sodium.h>
+
+static constexpr size_t WIREFOX_SODIUM_NONCE_LEN = crypto_aead_xchacha20poly1305_ietf_NPUBBYTES;
+static constexpr size_t WIREFOX_SODIUM_MAC_LEN = crypto_secretbox_xchacha20poly1305_MACBYTES;
 
 using namespace detail;
 
@@ -15,6 +27,35 @@ namespace {
         return buffer;
     }
 
+#ifdef WIREFOX_SODIUM_MONITORING
+    void PrintKeyToStdout(const char* prefix, uint8_t* key) {
+        std::cout << prefix << std::hex;
+        for (int i = 0; i < 32; i++)
+            std::cout << int(key[i]);
+
+        std::cout << std::dec << std::endl;
+    }
+#endif
+
+}
+
+std::shared_ptr<EncryptionLayerSodium::Keypair> EncryptionLayerSodium::Keypair::CreateIdentity() {
+    // create a keypair that represents a persistent identity (e.g. to be used for signing challenges)
+    auto ret = std::make_shared<Keypair>();
+    crypto_box_keypair(ret->key_public, ret->key_secret);
+    return ret;
+}
+
+std::shared_ptr<EncryptionLayerSodium::Keypair> EncryptionLayerSodium::Keypair::CreateKeyExchange() {
+    // create an ephemeral keypair that is to be used for ECDH key exchange, and has no meaning beyond that
+    auto ret = std::make_shared<Keypair>();
+    crypto_kx_keypair(ret->key_public, ret->key_secret);
+    return ret;
+}
+
+void EncryptionLayerSodium::Keypair::CopyTo(uint8_t* out_secret, uint8_t* out_public) const {
+    memcpy(out_secret, key_secret, KEY_LENGTH);
+    memcpy(out_public, key_public, KEY_LENGTH);
 }
 
 EncryptionLayerSodium::Keypair::Keypair()
@@ -23,7 +64,10 @@ EncryptionLayerSodium::Keypair::Keypair()
     if (sodium_init() < 0)
         throw std::runtime_error("libsodium failed to init");
 
-    crypto_kx_keypair(key_public, key_secret);
+    // the secure variants are not required here because the uninitialized memory is irrelevant garbage for us,
+    // so I don't see the need to call a slower, more complex memzero if we're overwriting it anyway
+    memset(key_public, 0, KEY_LENGTH);
+    memset(key_secret, 0, KEY_LENGTH);
 }
 
 EncryptionLayerSodium::Keypair::Keypair(const uint8_t* key_secret, const uint8_t* key_public)
@@ -39,19 +83,26 @@ EncryptionLayerSodium::Keypair::~Keypair() {
 }
 
 EncryptionLayerSodium::EncryptionLayerSodium()
-    : m_key_expect_pub{}
+    : m_remote_identity_pk{}
+    , m_issued_challenge{}
     , m_key_rx{}
     , m_key_tx{}
     , m_error(false)
-    , m_knowsRemotePubkey(false) {
+    , m_established(false)
+    , m_remoteIdentityKnown(false)
+    , m_remoteAuthExpected(false) {
     // asserts done here to make sure the key array sizes match up with what libsodium expects;
     // I don't want to include sodium.h publically so can't use the macros there directly
-    static_assert(crypto_kx_PUBLICKEYBYTES == KEY_LENGTH, "bad public key array size");
-    static_assert(crypto_kx_SECRETKEYBYTES == KEY_LENGTH, "bad private key array size");
-    static_assert(crypto_kx_SESSIONKEYBYTES == KEY_LENGTH, "bad session key array size");
+    static_assert(crypto_kx_PUBLICKEYBYTES == KEY_LENGTH, "kx public key size must match KEY_LENGTH");
+    static_assert(crypto_kx_SECRETKEYBYTES == KEY_LENGTH, "kx private key size must match KEY_LENGTH");
+    static_assert(crypto_kx_SESSIONKEYBYTES == KEY_LENGTH, "kx session key size must match KEY_LENGTH");
+    static_assert(crypto_box_PUBLICKEYBYTES == KEY_LENGTH, "identity public key size must match KEY_LENGTH");
+    static_assert(crypto_box_SECRETKEYBYTES == KEY_LENGTH, "identity private key size must match KEY_LENGTH");
 
     if (sodium_init() < 0)
         throw std::runtime_error("libsodium failed to init");
+
+    m_kx = Keypair::CreateKeyExchange();
 }
 
 EncryptionLayerSodium::EncryptionLayerSodium(EncryptionLayerSodium&& other) noexcept
@@ -61,7 +112,7 @@ EncryptionLayerSodium::EncryptionLayerSodium(EncryptionLayerSodium&& other) noex
 
 EncryptionLayerSodium::~EncryptionLayerSodium() {
     // securely erase all keys from memory
-    sodium_memzero(m_key_expect_pub, KEY_LENGTH);
+    sodium_memzero(m_remote_identity_pk, KEY_LENGTH);
     sodium_memzero(m_key_tx, KEY_LENGTH);
     sodium_memzero(m_key_tx, KEY_LENGTH);
 }
@@ -69,19 +120,24 @@ EncryptionLayerSodium::~EncryptionLayerSodium() {
 EncryptionLayerSodium& EncryptionLayerSodium::operator=(EncryptionLayerSodium&& other) noexcept {
     if (this != &other) {
         m_kx = std::move(other.m_kx);
+        m_identity = std::move(other.m_identity);
 
-        memcpy(m_key_expect_pub, other.m_key_expect_pub, sizeof m_key_expect_pub);
+        memcpy(m_remote_identity_pk, other.m_remote_identity_pk, sizeof m_remote_identity_pk);
         memcpy(m_key_rx, other.m_key_rx, sizeof m_key_rx);
         memcpy(m_key_tx, other.m_key_tx, sizeof m_key_tx);
 
-        sodium_memzero(other.m_key_expect_pub, sizeof m_key_expect_pub);
+        sodium_memzero(other.m_remote_identity_pk, sizeof m_remote_identity_pk);
         sodium_memzero(other.m_key_rx, sizeof m_key_rx);
         sodium_memzero(other.m_key_tx, sizeof m_key_tx);
 
         m_error = other.m_error;
-        m_knowsRemotePubkey = other.m_knowsRemotePubkey;
+        m_established = other.m_established;
+        m_remoteIdentityKnown = other.m_remoteIdentityKnown;
+        m_remoteAuthExpected = other.m_remoteAuthExpected;
         other.m_error = false;
-        other.m_knowsRemotePubkey = false;
+        other.m_established = false;
+        other.m_remoteIdentityKnown = false;
+        other.m_remoteAuthExpected = false;
     }
     return *this;
 }
@@ -91,29 +147,72 @@ bool EncryptionLayerSodium::GetNeedsToBail() const {
 }
 
 size_t EncryptionLayerSodium::GetOverhead() {
-    return crypto_secretbox_MACBYTES + crypto_secretbox_NONCEBYTES;
+    return WIREFOX_SODIUM_NONCE_LEN + WIREFOX_SODIUM_MAC_LEN;
 }
 
 size_t EncryptionLayerSodium::GetKeyLength() {
     return KEY_LENGTH;
 }
 
-BinaryStream EncryptionLayerSodium::GetPublicKey() const {
+BinaryStream EncryptionLayerSodium::GetEphemeralPublicKey() const {
+#ifdef WIREFOX_SODIUM_MONITORING
+    PrintKeyToStdout("kxpk = ", m_kx->key_public);
+#endif
     BinaryStream ret(KEY_LENGTH);
     ret.WriteBytes(m_kx->key_public, KEY_LENGTH);
     ret.SeekToBegin();
     return ret;
 }
 
-bool EncryptionLayerSodium::SetRemotePublicKey(Handshaker::Origin origin, BinaryStream& pubkey) {
+void EncryptionLayerSodium::SetCryptoEstablished() {
+    m_established = true;
+}
+
+bool EncryptionLayerSodium::GetCryptoEstablished() const {
+    return m_established;
+}
+
+bool EncryptionLayerSodium::GetNeedsChallenge() const {
+    return m_remoteIdentityKnown;
+}
+
+void EncryptionLayerSodium::CreateChallenge(BinaryStream& outstream) {
+    // state flag to remember we want an answer to this challenge
+    m_remoteAuthExpected = true;
+
+    // random nonce
+    //uint8_t nonce[WIREFOX_SODIUM_NONCE_LEN];
+    //randombytes_buf(nonce, sizeof nonce);
+
+    // just generate some random bytes to be used as challenge
+    uint8_t encrypted[CHALLENGE_LENGTH + crypto_box_SEALBYTES];
+    randombytes_buf(m_issued_challenge, CHALLENGE_LENGTH);
+    //crypto_aead_xchacha20poly1305_ietf_encrypt(encrypted, m_issued_challenge, CHALLENGE_LENGTH, nullptr, 0, nullptr, nonce, )
+    //crypto_sign_detached(encrypted, nullptr, m_issued_challenge, CHALLENGE_LENGTH, m_identity->key_secret);
+    crypto_box_seal(encrypted, m_issued_challenge, CHALLENGE_LENGTH, m_remote_identity_pk);
+
+#ifdef WIREFOX_SODIUM_MONITORING
+    PrintKeyToStdout("original challenge = ", m_issued_challenge);
+    PrintKeyToStdout("encrypt  challenge = ", encrypted);
+#endif
+
+    outstream.WriteBytes(encrypted, sizeof encrypted);
+}
+
+bool EncryptionLayerSodium::HandleKeyExchange(Handshaker::Origin origin, BinaryStream& pubkey) {
     uint8_t remotekey[KEY_LENGTH];
     pubkey.ReadBytes(remotekey, KEY_LENGTH);
 
+#ifdef WIREFOX_SODIUM_MONITORING
+    PrintKeyToStdout("pk = ", remotekey);
+#endif
+
     // verify identity of remote, if we know the key already
-    if (m_knowsRemotePubkey && sodium_memcmp(remotekey, m_key_expect_pub, KEY_LENGTH) != 0) {
-        // mismatch, remote may be an impostor
-        return false;
-    }
+    // EDIT: cannot do this here anymore because KX public key has nothing to do with remote identity
+    //if (m_remoteIdentityKnown && sodium_memcmp(remotekey, m_remote_identity_pk, KEY_LENGTH) != 0) {
+    //    // mismatch, remote may be an impostor
+    //    return false;
+    //}
 
     switch (origin) {
     case Handshaker::Origin::SELF:
@@ -125,34 +224,66 @@ bool EncryptionLayerSodium::SetRemotePublicKey(Handshaker::Origin origin, Binary
             m_error = true;
         break;
     default:
-        assert(false && "invalid Handshaker::Origin in EncryptionLayerSodium::SetRemotePublicKey");
+        assert(false && "invalid Handshaker::Origin in EncryptionLayerSodium::HandleKeyExchange");
         break;
     }
+
+#ifdef WIREFOX_SODIUM_MONITORING
+    PrintKeyToStdout("rx = ", m_key_rx);
+    PrintKeyToStdout("tx = ", m_key_tx);
+#endif
 
     return !m_error;
 }
 
-void EncryptionLayerSodium::SetLocalKeypair(std::shared_ptr<EncryptionLayer::Keypair> keypair) {
-    m_kx = std::static_pointer_cast<EncryptionLayerSodium::Keypair>(keypair);
+bool EncryptionLayerSodium::HandleChallengeResponse(BinaryStream& instream) {
+    uint8_t response[CHALLENGE_LENGTH];
+    instream.ReadBytes(response, sizeof response);
+
+    return sodium_memcmp(response, m_issued_challenge, CHALLENGE_LENGTH) == 0;
 }
 
-void EncryptionLayerSodium::ExpectRemotePublicKey(BinaryStream& pubkey) {
-    m_knowsRemotePubkey = true;
-    pubkey.ReadBytes(m_key_expect_pub, KEY_LENGTH);
+bool EncryptionLayerSodium::HandleChallengeIncoming(BinaryStream& instream, BinaryStream& answer) {
+    uint8_t encrypted[CHALLENGE_LENGTH + crypto_box_SEALBYTES];
+    uint8_t decrypted[CHALLENGE_LENGTH];
+    instream.ReadBytes(encrypted, sizeof encrypted);
+
+    // decrypt the challenge using our identity's private key; the remote should've encrypted using our public key
+    if (crypto_box_seal_open(decrypted, encrypted, sizeof encrypted, m_identity->key_public, m_identity->key_secret) != 0)
+        return false;
+
+#ifdef WIREFOX_SODIUM_MONITORING
+    PrintKeyToStdout("received challenge = ", encrypted);
+    PrintKeyToStdout("decrypt  challenge = ", decrypted);
+#endif
+
+    // now that we have the decrypted challenge, write it out
+    answer.WriteBytes(decrypted, sizeof decrypted);
+    return true;
+}
+
+void EncryptionLayerSodium::SetLocalIdentity(std::shared_ptr<EncryptionLayer::Keypair> keypair) {
+    m_identity = std::static_pointer_cast<EncryptionLayerSodium::Keypair>(keypair);
+}
+
+void EncryptionLayerSodium::ExpectRemoteIdentity(BinaryStream& pubkey) {
+    m_remoteIdentityKnown = true;
+    pubkey.ReadBytes(m_remote_identity_pk, KEY_LENGTH);
 }
 
 BinaryStream EncryptionLayerSodium::Encrypt(const BinaryStream& plaintext) {
     // allocate a buffer long enough to hold the full ciphertext
-    const size_t ciphertext_len_full = plaintext.GetLength() + crypto_secretbox_MACBYTES + crypto_secretbox_NONCEBYTES;
+    const size_t ciphertext_len_full = plaintext.GetLength() + WIREFOX_SODIUM_MAC_LEN + WIREFOX_SODIUM_NONCE_LEN;
     BinaryStream ciphertext = PreallocateBuffer(ciphertext_len_full);
-    auto* ciphertext_ptr = ciphertext.GetWritableBuffer() + crypto_secretbox_NONCEBYTES;
+    auto* ciphertext_ptr = ciphertext.GetWritableBuffer() + WIREFOX_SODIUM_NONCE_LEN;
 
     // get a random nonce, and add it to the full ciphertext as prefix
-    uint8_t nonce[crypto_secretbox_NONCEBYTES];
+    uint8_t nonce[WIREFOX_SODIUM_NONCE_LEN];
     randombytes_buf(nonce, sizeof nonce);
     ciphertext.WriteBytes(nonce, sizeof nonce);
 
     // encrypt the plaintext and write it to the output BinaryStream
+    //crypto_aead_xchacha20poly1305_ietf_encrypt()
     crypto_secretbox_easy(ciphertext_ptr, plaintext.GetBuffer(), plaintext.GetLength(), nonce, m_key_tx);
 
     ciphertext.SeekToBegin();
@@ -161,20 +292,22 @@ BinaryStream EncryptionLayerSodium::Encrypt(const BinaryStream& plaintext) {
 
 BinaryStream EncryptionLayerSodium::Decrypt(BinaryStream& ciphertext) {
     // read out the nonce from the stream
-    uint8_t nonce[crypto_secretbox_NONCEBYTES];
+    uint8_t nonce[WIREFOX_SODIUM_NONCE_LEN];
     assert(ciphertext.GetPosition() == 0); // because we do pointer arithmetic below, which assumes the full ciphertext starts at GetBuffer()
     ciphertext.SeekToBegin();
     ciphertext.ReadBytes(nonce, sizeof nonce);
 
-    assert(ciphertext.GetLength() >= crypto_secretbox_MACBYTES + crypto_secretbox_NONCEBYTES);
-    const size_t plaintext_len = ciphertext.GetLength() - crypto_secretbox_MACBYTES - crypto_secretbox_NONCEBYTES;
-    const size_t ciphertext_len = ciphertext.GetLength() - crypto_secretbox_NONCEBYTES;
+    assert(ciphertext.GetLength() >= WIREFOX_SODIUM_MAC_LEN + WIREFOX_SODIUM_NONCE_LEN);
+    const auto* ciphertext_ptr = ciphertext.GetBuffer() + WIREFOX_SODIUM_NONCE_LEN;
+    const size_t ciphertext_len = ciphertext.GetLength() - WIREFOX_SODIUM_NONCE_LEN;
+    const size_t plaintext_len = ciphertext_len - WIREFOX_SODIUM_MAC_LEN;
 
     // allocate a buffer long enough to hold the decrypted plaintext
     BinaryStream plaintext = PreallocateBuffer(plaintext_len);
     assert(plaintext.GetCapacity() >= plaintext_len);
+
     // perform decryption
-    if (crypto_secretbox_open_easy(plaintext.GetWritableBuffer(), ciphertext.GetBuffer() + crypto_secretbox_NONCEBYTES, ciphertext_len, nonce, m_key_rx) != 0)
+    if (crypto_secretbox_open_easy(plaintext.GetWritableBuffer(), ciphertext_ptr, ciphertext_len, nonce, m_key_rx) != 0)
         m_error = true;
 
     return plaintext;

--- a/source/EncryptionLayerSodium.h
+++ b/source/EncryptionLayerSodium.h
@@ -1,0 +1,63 @@
+/**
+ * Wirefox Networking API
+ * (C) Mika Molenkamp, 2019.
+ *
+ * Licensed under the BSD 3-Clause License, see the LICENSE file in the project
+ * root folder for more information.
+ */
+
+#pragma once
+#include "EncryptionLayer.h"
+
+#ifdef WIREFOX_ENABLE_ENCRYPTION
+
+namespace wirefox {
+
+    namespace detail {
+
+        /**
+         * \cond WIREFOX_INTERNAL
+         * \brief Represents a cryptography layer implemented using libsodium.
+         */
+        class EncryptionLayerSodium : public EncryptionLayer {
+        public:
+            EncryptionLayerSodium();
+            EncryptionLayerSodium(const EncryptionLayerSodium&) = delete;
+            EncryptionLayerSodium(EncryptionLayerSodium&&) noexcept;
+            virtual ~EncryptionLayerSodium();
+
+            EncryptionLayerSodium& operator=(const EncryptionLayerSodium&) = delete;
+            EncryptionLayerSodium& operator=(EncryptionLayerSodium&&) noexcept;
+
+            bool GetNeedsToBail() const override;
+            size_t GetOverhead() const override;
+
+            BinaryStream GetPublicKey() const override;
+            void SetRemotePublicKey(Handshaker::Origin origin, BinaryStream& pubkey) override;
+
+            BinaryStream Encrypt(const BinaryStream& plaintext) override;
+            BinaryStream Decrypt(BinaryStream& ciphertext) override;
+
+        private:
+            static constexpr size_t KEY_LENGTH = 32;
+
+            /// Key exchange key, secret part.
+            uint8_t m_kx_secret[KEY_LENGTH];
+            /// Key exchange key, public part.
+            uint8_t m_kx_public[KEY_LENGTH];
+
+            /// Session key for decrypting received messages.
+            uint8_t m_key_rx[KEY_LENGTH];
+            /// Session key for encrypting outgoing messages.
+            uint8_t m_key_tx[KEY_LENGTH];
+
+            bool m_error;
+        };
+
+        /// \endcond
+
+    }
+
+}
+
+#endif

--- a/source/EncryptionLayerSodium.h
+++ b/source/EncryptionLayerSodium.h
@@ -48,8 +48,9 @@ namespace wirefox {
             bool GetNeedsToBail() const override;
 
             BinaryStream GetPublicKey() const override;
-            void SetRemotePublicKey(Handshaker::Origin origin, BinaryStream& pubkey) override;
+            bool SetRemotePublicKey(Handshaker::Origin origin, BinaryStream& pubkey) override;
             void SetLocalKeypair(std::shared_ptr<EncryptionLayer::Keypair> keypair) override;
+            void ExpectRemotePublicKey(BinaryStream& pubkey) override;
 
             BinaryStream Encrypt(const BinaryStream& plaintext) override;
             BinaryStream Decrypt(BinaryStream& ciphertext) override;
@@ -68,12 +69,16 @@ namespace wirefox {
             /// A handle to the local peer's keypair.
             std::shared_ptr<Keypair> m_kx;
 
+            /// The remote public key, if known beforehand.
+            uint8_t m_key_expect_pub[KEY_LENGTH];
+
             /// Session key for decrypting received messages.
             uint8_t m_key_rx[KEY_LENGTH];
             /// Session key for encrypting outgoing messages.
             uint8_t m_key_tx[KEY_LENGTH];
 
             bool m_error;
+            bool m_knowsRemotePubkey;
         };
 
         /// \endcond

--- a/source/Handshaker.cpp
+++ b/source/Handshaker.cpp
@@ -84,10 +84,7 @@ void Handshaker::Update() {
 
     // ensure we're not poking at this object from both the packet and socket thread
     std::unique_lock<decltype(m_remote->lock)> lock(m_remote->lock, std::try_to_lock);
-    if (!lock.owns_lock()) {
-        std::cout << "Skip handshaker update" << std::endl;
-        return;
-    }
+    if (!lock.owns_lock()) return;
 
     // There is one edge case where m_lastReply might be empty: if a new remote was reserved for an incoming
     // handshake part, but that handshake was a stage mismatch, so it was silently ignored and no Reply was recorded.

--- a/source/Handshaker.h
+++ b/source/Handshaker.h
@@ -21,6 +21,7 @@ namespace wirefox {
         struct PacketHeader;
         struct RemotePeer;
         class Peer;
+        class EncryptionAuthenticator;
 
         /**
          * \cond WIREFOX_INTERNAL
@@ -103,6 +104,8 @@ namespace wirefox {
 
             RemotePeer*             m_remote;
             Peer*                   m_peer;
+
+            std::unique_ptr<EncryptionAuthenticator> m_auth;
 
         private:
             ReplyHandler_t          m_replyHandler;

--- a/source/HandshakerThreeWay.cpp
+++ b/source/HandshakerThreeWay.cpp
@@ -141,10 +141,9 @@ void HandshakerThreeWay::Handle(const Packet& packet) {
         auto authresult = m_auth->Handle(instream, reply);
 
         // send intermediate messages to remote party
-        if ((authresult == ConnectResult::IN_PROGRESS) ||
-            (authresult == ConnectResult::OK && GetOrigin() == Origin::SELF)) {
-            Reply(std::move(reply));
-        }
+        Reply(std::move(reply));
+        m_auth->PostHandle();
+
         // mark handshake result
         if (authresult != ConnectResult::IN_PROGRESS) {
             Complete(authresult);

--- a/source/HandshakerThreeWay.cpp
+++ b/source/HandshakerThreeWay.cpp
@@ -141,7 +141,8 @@ void HandshakerThreeWay::Handle(const Packet& packet) {
         auto authresult = m_auth->Handle(instream, reply);
 
         // send intermediate messages to remote party
-        Reply(std::move(reply));
+        if (!reply.IsEmpty())
+            Reply(std::move(reply));
         m_auth->PostHandle();
 
         // mark handshake result

--- a/source/HandshakerThreeWay.cpp
+++ b/source/HandshakerThreeWay.cpp
@@ -13,38 +13,40 @@
 
 using namespace wirefox::detail;
 
-static constexpr size_t HANDSHAKE_LENGTH =
+static constexpr size_t HANDSHAKE_HEADER_LEN =
     sizeof(cfg::WIREFOX_MAGIC) +    // magic number //-V119
     sizeof(uint8_t) +               // protocol version
     sizeof(PeerID) +                // peerID exchange
-    sizeof(uint8_t) +               // handshake stage
-    sizeof(uint8_t);                // error code, if stage == 2
+    sizeof(uint8_t);                // handshake stage
 
 void HandshakerThreeWay::Begin() {
     // Begin should only be called if this local socket is the one initiating the connection
     assert(GetOrigin() == Origin::SELF);
 
     // write a connection request and send it
-    BinaryStream hello(HANDSHAKE_LENGTH);
+    BinaryStream hello(HANDSHAKE_HEADER_LEN);
     WriteReplyHeader(hello, m_peer->GetMyPeerID());
-    hello.WriteByte(0); // connection phase 0
-
-    // key exchange
+    hello.WriteByte(INITIAL_CLIENT);
     hello.WriteBool(m_peer->GetEncryptionEnabled());
-    if (m_peer->GetEncryptionEnabled())
-        hello.WriteBytes(m_remote->crypto->GetPublicKey());
 
-    m_status = AWAITING_ACK;
+    m_expectedOpcode = INITIAL_SERVER;
     Reply(std::move(hello));
 }
 
 void HandshakerThreeWay::Handle(const Packet& packet) {
     if (IsDone()) return;
 
+    WIREFOX_LOCK_GUARD(m_remote->lock);
+
     // prepare the leading part of the reply
     BinaryStream instream = packet.GetStream();
-    BinaryStream reply(HANDSHAKE_LENGTH);
+    BinaryStream reply(HANDSHAKE_HEADER_LEN);
     WriteReplyHeader(reply, m_peer->GetMyPeerID());
+
+    if (instream.IsEOF(HANDSHAKE_HEADER_LEN)) {
+        // handshake header not long enough, don't bother parsing it
+        Complete(ConnectResult::INCOMPATIBLE_PROTOCOL);
+    }
 
 
     // read and compare the magic number, to make sure we're talking to a Wirefox endpoint
@@ -66,7 +68,7 @@ void HandshakerThreeWay::Handle(const Packet& packet) {
 
     // now that that's out of the way, read some state data
     const PeerID remoteID = instream.ReadUInt64();
-    const uint8_t stage = instream.ReadByte();
+    const uint8_t opcode = instream.ReadByte();
 
     auto* competitor = m_peer->GetRemoteByID(remoteID);
     if (competitor && competitor != m_remote) {
@@ -79,9 +81,7 @@ void HandshakerThreeWay::Handle(const Packet& packet) {
     m_remote->id = remoteID;
 
     // discard packets that mismatch with our expected stage; they're probably resends or delayed arrivals
-    if (stage == 0 && m_status == AWAITING_ACK) return;
-    if (stage == 1 && m_status == NOT_STARTED) return;
-    if (stage == 2) {
+    if (opcode == ERROR_OCCURRED) {
         // stage 2 is an error report & indicates failure
         const auto problem = static_cast<ConnectResult>(instream.ReadByte());
         assert(problem != ConnectResult::OK && problem != ConnectResult::IN_PROGRESS);
@@ -89,64 +89,72 @@ void HandshakerThreeWay::Handle(const Packet& packet) {
         return;
     }
 
-    // set up connection security
-    assert(m_remote->crypto);
-    if (!m_keySetupDone) {
+    // for clarity: even though this is p2p networking, below I refer to the 'client' as the one who initiated
+    // the connection request, and the 'server' as the one who the client wants to connect to.
+
+    if (m_expectedOpcode == NOT_STARTED && opcode == INITIAL_CLIENT) {
+        // we're the server, and client just sent first part of handshake
+        //assert(opcode == INITIAL_CLIENT);
+        assert(GetOrigin() == Origin::REMOTE);
+        //if (opcode != INITIAL_CLIENT) return;
+
+        // make sure that both sides agree whether they want security or not
+        assert(m_remote->crypto);
         bool remoteWantsCrypto = instream.ReadBool();
         if (remoteWantsCrypto != m_peer->GetEncryptionEnabled()) {
-            // both peers must agree on whether or not encryption is enabled
             ReplyWithError(reply, ConnectResult::INCOMPATIBLE_SECURITY);
             Complete(ConnectResult::INCOMPATIBLE_SECURITY);
             return;
         }
-        if (remoteWantsCrypto) {
-            // read out the remote public key into a buffer
-            const auto keylen = cfg::DefaultEncryption::GetKeyLength();
-            const auto remoteKeyBuffer = std::make_unique<uint8_t[]>(keylen);
-            instream.ReadBytes(remoteKeyBuffer.get(), keylen);
 
-            // pass the buffer to the crypto layer, so the key exchange can be completed
-            BinaryStream remoteKey(remoteKeyBuffer.get(), keylen, BinaryStream::WrapMode::READONLY);
-            if (!m_remote->crypto->SetRemotePublicKey(GetOrigin(), remoteKey)) {
-                // if this setter returns false, then there is something wrong/suspicious about the key
-                ReplyWithError(reply, ConnectResult::INCORRECT_REMOTE_IDENTITY); // TODO: is it OK to tell the remote this?
-                Complete(ConnectResult::INCORRECT_REMOTE_IDENTITY);
-            }
-        }
-        // don't need to read the public key again
-        m_keySetupDone = true;
-    }
-
-    // for clarity: even though this is p2p networking, below I refer to the 'client' as the one who initiated
-    // the connection request, and the 'server' as the one who the client wants to connect to.
-
-    if (m_status == NOT_STARTED) {
-        // we're the server, and client just sent first part of handshake
-        m_status = AWAITING_ACK;
-        reply.WriteByte(1);
+        m_expectedOpcode = m_peer->GetEncryptionEnabled() ? AUTH_MSG : UNENCRYPTED_ACK;
+        reply.WriteByte(INITIAL_SERVER);
         reply.WriteBool(m_peer->GetEncryptionEnabled());
-        if (m_peer->GetEncryptionEnabled())
-            reply.WriteBytes(m_remote->crypto->GetPublicKey());
         Reply(std::move(reply));
 
-    } else if (/*m_status == AWAITING_ACK &&*/ GetOrigin() == Origin::REMOTE) {
-        // we're the server, and client just sent part 3 of the handshake, we're done
+    } else if (m_expectedOpcode == UNENCRYPTED_ACK && opcode == m_expectedOpcode) {
+        // we're the server, and client just sent part 3 of the handshake
+        assert(GetOrigin() == Origin::REMOTE);
+        // three-way handshake completed
         Complete(ConnectResult::OK);
 
-    } else if (/*m_status == AWAITING_ACK &&*/ GetOrigin() == Origin::SELF) {
-        // we're the client, and server just replied to our request, so ack that
-        reply.WriteByte(1);
+    } else if (m_expectedOpcode == INITIAL_SERVER && opcode == m_expectedOpcode) {
+        // we're the client, and server just replied to our initial request
+        assert(GetOrigin() == Origin::SELF);
+
+        if (m_peer->GetEncryptionEnabled()) {
+            // basic handshake is now finished, begin crypto key exchange
+            reply.WriteByte(AUTH_MSG);
+            m_expectedOpcode = AUTH_MSG;
+            m_auth->Begin(reply);
+        } else {
+            reply.WriteByte(UNENCRYPTED_ACK);
+            // TODO: not strictly speaking done yet! kinda need to wait for an ack first. If we now start sending data
+            // TODO: (flag_link) and that data arrives *before* the handshake, then the server kills the connection.
+            Complete(ConnectResult::OK);
+        }
+
         Reply(std::move(reply));
 
-        // TODO: not strictly speaking done yet! kinda need to wait for an ack first. If we now start sending data
-        // TODO: (flag_link) and that data arrives *before* the handshake, then the server kills the connection.
-        Complete(ConnectResult::OK);
+    } else if (m_expectedOpcode == AUTH_MSG && opcode == m_expectedOpcode) {
+        reply.WriteByte(AUTH_MSG);
+        auto authresult = m_auth->Handle(instream, reply);
+
+        // send intermediate messages to remote party
+        if ((authresult == ConnectResult::IN_PROGRESS) ||
+            (authresult == ConnectResult::OK && GetOrigin() == Origin::SELF)) {
+            Reply(std::move(reply));
+        }
+        // mark handshake result
+        if (authresult != ConnectResult::IN_PROGRESS) {
+            Complete(authresult);
+        }
     }
 }
 
 void HandshakerThreeWay::WriteOutOfBandErrorReply(BinaryStream& outstream, PeerID myID, ConnectResult reply) {
     WriteReplyHeader(outstream, myID);
-    outstream.WriteByte(2); // stage 2 indicates error
+    outstream.WriteByte(ERROR_OCCURRED);
     outstream.WriteByte(static_cast<uint8_t>(reply));
 }
 
@@ -157,7 +165,7 @@ void HandshakerThreeWay::WriteReplyHeader(BinaryStream& outstream, PeerID myID) 
 }
 
 void HandshakerThreeWay::ReplyWithError(BinaryStream& outstream, ConnectResult problem) {
-    outstream.WriteByte(2); // stage 2 indicates error
+    outstream.WriteByte(ERROR_OCCURRED); // stage 2 indicates error
     outstream.WriteByte(static_cast<uint8_t>(problem));
     Reply(std::move(outstream));
 }

--- a/source/HandshakerThreeWay.h
+++ b/source/HandshakerThreeWay.h
@@ -31,7 +31,8 @@ namespace wirefox {
              */
             HandshakerThreeWay(Peer* master, RemotePeer* remote, Origin origin)
                 : Handshaker(master, remote, origin)
-                , m_status(NOT_STARTED) {}
+                , m_status(NOT_STARTED)
+                , m_keySetupDone(false) {}
 
             void            Begin() override;
             void            Handle(const Packet& packet) override;
@@ -53,6 +54,7 @@ namespace wirefox {
                 NOT_STARTED,
                 AWAITING_ACK
             }               m_status;
+            bool            m_keySetupDone;
         };
 
         /// \endcond

--- a/source/HandshakerThreeWay.h
+++ b/source/HandshakerThreeWay.h
@@ -31,8 +31,7 @@ namespace wirefox {
              */
             HandshakerThreeWay(Peer* master, RemotePeer* remote, Origin origin)
                 : Handshaker(master, remote, origin)
-                , m_status(NOT_STARTED)
-                , m_keySetupDone(false) {}
+                , m_expectedOpcode(NOT_STARTED) {}
 
             void            Begin() override;
             void            Handle(const Packet& packet) override;
@@ -50,11 +49,14 @@ namespace wirefox {
             static void     WriteReplyHeader(BinaryStream& outstream, PeerID myID);
             void            ReplyWithError(BinaryStream& outstream, ConnectResult problem);
 
-            enum {
+            enum : uint8_t {
                 NOT_STARTED,
-                AWAITING_ACK
-            }               m_status;
-            bool            m_keySetupDone;
+                INITIAL_CLIENT,
+                INITIAL_SERVER,
+                AUTH_MSG,
+                UNENCRYPTED_ACK,
+                ERROR_OCCURRED
+            } m_expectedOpcode;
         };
 
         /// \endcond

--- a/source/PacketQueue.cpp
+++ b/source/PacketQueue.cpp
@@ -191,8 +191,6 @@ void PacketQueue::DoWriteCycle(RemotePeer& remote) {
         // if key exchange was completed already, replace the datagram blob with a ciphertext
         const bool encryptionDesired = crypto && crypto->GetCryptoEstablished();
         if (encryptionDesired) {
-            if (datagram->forceCrypto) std::cout << "Forcing crypto" << std::endl;
-            std::cout << "Encrypting packet" << std::endl;
             datagram->blob = crypto->Encrypt(datagram->blob);
 
             // I don't know why this would happen, but I guess encryption could fail?
@@ -238,7 +236,6 @@ void PacketQueue::OnReadFinished(bool error, const RemoteAddress& sender, const 
 
     // if we know the remote, then the message may be encrypted
     if (remote->crypto && remote->crypto->GetCryptoEstablished()) {
-        std::cout << "Decrypting packet" << std::endl;
         inbuffer = remote->crypto->Decrypt(inbuffer);
 
         // the ciphertext might be malformed for several reasons; decryption failure == bad connection

--- a/source/PacketQueue.h
+++ b/source/PacketQueue.h
@@ -38,11 +38,12 @@ namespace wirefox {
             struct OutgoingPacket {
                 BinaryStream    blob;       ///< A byte blob that contains both the packet header and payload.
                 RemoteAddress   addr;       ///< The remote endpoint this packet is addressed to.
-                Timestamp       sendNext;   ///< Indicates when this packet should be treated as lost and resent.
                 RemotePeer*     remote;     ///< The peer slot associated with this packet.
+                RemotePeer*     forceCrypto;///< If not nullptr, force this packet to be encrypted using this peer's crypto layer.
+                Timestamp       sendNext;   ///< Indicates when this packet should be treated as lost and resent.
+                unsigned int    sendCount;  ///< Indicates the number of times this packet has been sent.
                 PacketID        id;         ///< The ID number of this datagram, used for resending and acknowledgement.
                 PacketOptions   options;    ///< Reliability settings associated with this packet.
-                unsigned int    sendCount;  ///< Indicates the number of times this packet has been sent.
 
                 /// Returns a value indicating whether the given PacketOptions are set for this OutgoingPacket.
                 bool            HasFlag(PacketOptions test) const;
@@ -54,6 +55,7 @@ namespace wirefox {
                 RemoteAddress   addr;       ///< The remote endpoint this packet is addressed to.
                 BinaryStream    blob;       ///< A byte blob that contains both the datagram header and all packets, if any.
                 Timestamp       discard;    ///< The timestamp at which this datagram should be removed / cleaned up.
+                RemotePeer*     forceCrypto;///< If not nullptr, force this packet to be encrypted using this peer's crypto layer.
                 std::vector<PacketID> packets;  ///< The list of PacketIDs this datagram contains. Used for acking packets.
             };
 
@@ -90,7 +92,7 @@ namespace wirefox {
              * \param[in]   packet      The packet to send out.
              * \param[in]   addr        The raw remote address to send data to.
              */
-            void            EnqueueOutOfBand(const Packet& packet, const RemoteAddress& addr);
+            void            EnqueueOutOfBand(const Packet& packet, const RemoteAddress& addr, RemotePeer* forceCryptoBy);
 
             /**
              * \brief Send a message to this local socket.

--- a/source/PacketQueue.h
+++ b/source/PacketQueue.h
@@ -24,6 +24,7 @@ namespace wirefox {
         struct RemotePeer;
         class Peer;
         class Socket;
+        class EncryptionLayer;
 
         /**
          * \cond WIREFOX_INTERNAL
@@ -33,13 +34,15 @@ namespace wirefox {
          * fragmenting outgoing Packets into segments if necessary, and reassembling incoming Packets.
          */
         class PacketQueue : public std::enable_shared_from_this<PacketQueue> {
+            using CryptoPtr = std::shared_ptr<EncryptionLayer>;
+
         public:
             /// Represents an outbound packet that is not yet assigned to a datagram.
             struct OutgoingPacket {
+                CryptoPtr       crypto;     ///< If not nullptr, force this packet to be encrypted using this crypto layer.
                 BinaryStream    blob;       ///< A byte blob that contains both the packet header and payload.
                 RemoteAddress   addr;       ///< The remote endpoint this packet is addressed to.
                 RemotePeer*     remote;     ///< The peer slot associated with this packet.
-                RemotePeer*     forceCrypto;///< If not nullptr, force this packet to be encrypted using this peer's crypto layer.
                 Timestamp       sendNext;   ///< Indicates when this packet should be treated as lost and resent.
                 unsigned int    sendCount;  ///< Indicates the number of times this packet has been sent.
                 PacketID        id;         ///< The ID number of this datagram, used for resending and acknowledgement.
@@ -51,12 +54,12 @@ namespace wirefox {
 
             /// Represents an outbound datagram that is not yet fully delivered.
             struct OutgoingDatagram {
-                DatagramID      id;         ///< The ID number of this datagram.
-                RemoteAddress   addr;       ///< The remote endpoint this packet is addressed to.
+                CryptoPtr       crypto;     ///< If not nullptr, force this packet to be encrypted using this crypto layer.
                 BinaryStream    blob;       ///< A byte blob that contains both the datagram header and all packets, if any.
+                RemoteAddress   addr;       ///< The remote endpoint this packet is addressed to.
+                DatagramID      id;         ///< The ID number of this datagram.
                 Timestamp       discard;    ///< The timestamp at which this datagram should be removed / cleaned up.
-                RemotePeer*     forceCrypto;///< If not nullptr, force this packet to be encrypted using this peer's crypto layer.
-                std::vector<PacketID> packets;  ///< The list of PacketIDs this datagram contains. Used for acking packets.
+                std::vector<PacketID> packets; ///< The list of PacketIDs this datagram contains. Used for acking packets.
             };
 
             /**

--- a/source/Peer.cpp
+++ b/source/Peer.cpp
@@ -101,7 +101,6 @@ ConnectAttemptResult Peer::Connect(const std::string& host, uint16_t port, const
             return;
         }
 
-        std::cout << "do connect" << std::endl;
         slot->addr = addr;
         slot->socket = std::move(socket);
         SetupRemotePeerCallbacks(slot);
@@ -362,7 +361,7 @@ void Peer::OnSystemPacket(RemotePeer& remote, std::unique_ptr<Packet> packet) {
         OnDisconnect(remote, PacketCommand::NOTIFY_DISCONNECTED);
 
         Packet dc_ack(PacketCommand::DISCONNECT_ACK, nullptr, 0);
-        this->SendOutOfBand(dc_ack, remote.addr);
+        m_queue->EnqueueOutOfBand(dc_ack, remote.addr, &remote);
 
         remote.Reset();
         break;

--- a/source/Peer.cpp
+++ b/source/Peer.cpp
@@ -83,7 +83,10 @@ ConnectAttemptResult Peer::Connect(const std::string& host, uint16_t port, const
 
     if (public_key) {
         // cannot specify public key while also having crypto disabled, that's silly
-        if (!GetEncryptionEnabled()) return ConnectAttemptResult::INVALID_PARAMETER;
+        if (!GetEncryptionEnabled()) {
+            slot->Reset();
+            return ConnectAttemptResult::INVALID_PARAMETER;
+        }
 
         // tell this remote's crypto layer to expect this exact public key
         BinaryStream public_key_stream(public_key, cfg::DefaultEncryption::GetKeyLength(), BinaryStream::WrapMode::READONLY);

--- a/source/Peer.h
+++ b/source/Peer.h
@@ -9,6 +9,7 @@
 #pragma once
 #include "PeerAbstract.h"
 #include "PacketQueue.h"
+#include "EncryptionLayer.h"
 
 namespace wirefox {
 
@@ -44,7 +45,7 @@ namespace wirefox {
             /// Move assignment operator.
             Peer& operator=(Peer&&) noexcept;
 
-            ConnectAttemptResult        Connect(const std::string& host, uint16_t port) override;
+            ConnectAttemptResult        Connect(const std::string& host, uint16_t port, const uint8_t* public_key) override;
             bool                        Bind(SocketProtocol family, uint16_t port) override;
             void                        Disconnect(PeerID who, Timespan linger) override;
             void                        DisconnectImmediate(PeerID who) override;
@@ -68,6 +69,13 @@ namespace wirefox {
             void                        DisableOfflineAdvertisement() override;
             void                        Ping(const std::string& hostname, uint16_t port) const override;
             void                        PingLocalNetwork(uint16_t port) const override;
+
+            void                        SetEncryptionEnabled(bool enabled) override;
+            void                        SetEncryptionLocalKeypair(const uint8_t* key_secret, const uint8_t* key_public) override;
+            void                        GenerateKeypair(uint8_t* key_secret, uint8_t* key_public) const override;
+            size_t                      GetEncryptionKeyLength() const override;
+            bool                        GetEncryptionEnabled() const;
+            std::shared_ptr<EncryptionLayer::Keypair> GetEncryptionLocalKeypair() const;
 
             /**
              * \brief Sends an unconnected packet to an arbitrary remote endpoint.
@@ -207,6 +215,9 @@ namespace wirefox {
             std::shared_ptr<PacketQueue>    m_queue;
             std::map<PeerID, RemotePeer*>   m_remoteLookup;
             std::vector<ChannelMode>        m_channels;
+
+            std::shared_ptr<EncryptionLayer::Keypair> m_crypto_keypair;
+            bool m_crypto_enabled;
         };
 
         /// \endcond

--- a/source/Peer.h
+++ b/source/Peer.h
@@ -71,11 +71,11 @@ namespace wirefox {
             void                        PingLocalNetwork(uint16_t port) const override;
 
             void                        SetEncryptionEnabled(bool enabled) override;
-            void                        SetEncryptionLocalKeypair(const uint8_t* key_secret, const uint8_t* key_public) override;
-            void                        GenerateKeypair(uint8_t* key_secret, uint8_t* key_public) const override;
+            void                        SetEncryptionIdentity(const uint8_t* key_secret, const uint8_t* key_public) override;
+            void                        GenerateIdentity(uint8_t* key_secret, uint8_t* key_public) const override;
             size_t                      GetEncryptionKeyLength() const override;
             bool                        GetEncryptionEnabled() const;
-            std::shared_ptr<EncryptionLayer::Keypair> GetEncryptionLocalKeypair() const;
+            std::shared_ptr<EncryptionLayer::Keypair> GetEncryptionIdentity() const;
 
             /**
              * \brief Sends an unconnected packet to an arbitrary remote endpoint.
@@ -216,7 +216,7 @@ namespace wirefox {
             std::map<PeerID, RemotePeer*>   m_remoteLookup;
             std::vector<ChannelMode>        m_channels;
 
-            std::shared_ptr<EncryptionLayer::Keypair> m_crypto_keypair;
+            std::shared_ptr<EncryptionLayer::Keypair> m_crypto_identity;
             bool m_crypto_enabled;
         };
 

--- a/source/Peer.h
+++ b/source/Peer.h
@@ -190,7 +190,7 @@ namespace wirefox {
 
         private:
             void                        SetupRemotePeerCallbacks(RemotePeer* remote);
-            void                        SendHandshakePart(const RemotePeer* remote, BinaryStream&& outstream);
+            void                        SendHandshakePart(RemotePeer* remote, BinaryStream&& outstream);
             void                        SendHandshakeCompleteNotification(RemotePeer* remote, Packet&& notification);
 
             static PeerID               GeneratePeerID();

--- a/source/RemotePeer.cpp
+++ b/source/RemotePeer.cpp
@@ -124,7 +124,7 @@ void RemotePeer::Setup(Peer* master, Handshaker::Origin origin) {
 
     // used by remote #0 to stop handshake from being instantiated, as out-of-band comms should not do handshakes
     if (origin != Handshaker::Origin::INVALID) {
-        crypto = std::make_unique<cfg::DefaultEncryption>();
+        crypto = std::make_shared<cfg::DefaultEncryption>();
         crypto->SetLocalIdentity(master->GetEncryptionIdentity());
         handshake = std::make_unique<cfg::DefaultHandshaker>(master, this, origin);
     }

--- a/source/RemotePeer.cpp
+++ b/source/RemotePeer.cpp
@@ -124,14 +124,9 @@ void RemotePeer::Setup(Peer* master, Handshaker::Origin origin) {
 
     // used by remote #0 to stop handshake from being instantiated, as out-of-band comms should not do handshakes
     if (origin != Handshaker::Origin::INVALID) {
+        crypto = std::make_unique<cfg::DefaultEncryption>();
+        crypto->SetLocalIdentity(master->GetEncryptionIdentity());
         handshake = std::make_unique<cfg::DefaultHandshaker>(master, this, origin);
-
-        if (master->GetEncryptionEnabled()) {
-            crypto = std::make_unique<cfg::DefaultEncryption>();
-            crypto->SetLocalKeypair(master->GetEncryptionLocalKeypair());
-        }
-        else
-            crypto = std::make_unique<EncryptionLayerNull>();
     }
 }
 

--- a/source/RemotePeer.h
+++ b/source/RemotePeer.h
@@ -27,7 +27,7 @@ namespace wirefox {
             RemotePeer();
             ~RemotePeer() = default;
 
-            /// Represents a synchronization primitive. This is used to sync access to the outbox and sentbox.
+            /// Represents a synchronization primitive, used to sync access before most operations.
             cfg::RecursiveMutex lock;
 
             /// A sparse array of channel backlogs. Ordered / sequenced packets may be temporarily held here.
@@ -45,6 +45,9 @@ namespace wirefox {
             /// A handle to the Socket that should be used to send datagrams to \p addr.
             std::shared_ptr<Socket> socket;
 
+            /// A handle to a cryptographic utility class.
+            std::shared_ptr<EncryptionLayer> crypto;
+
             /// A handle to the Handshaker that is to be used for this connection.
             std::unique_ptr<Handshaker> handshake;
 
@@ -53,9 +56,6 @@ namespace wirefox {
 
             /// A handle to an object that services requests for delivery receipts.
             std::unique_ptr<ReceiptTracker> receipt;
-
-            /// A handle to a cryptographic utility class.
-            std::unique_ptr<EncryptionLayer> crypto;
 
             /// The unique ID number of this remote endpoint. May be zero if handshake incomplete.
             PeerID id;

--- a/source/RemotePeer.h
+++ b/source/RemotePeer.h
@@ -13,6 +13,7 @@
 #include "CongestionControl.h"
 #include "ChannelBuffer.h"
 #include "ReceiptTracker.h"
+#include "EncryptionLayer.h"
 
 namespace wirefox {
 
@@ -52,6 +53,9 @@ namespace wirefox {
 
             /// A handle to an object that services requests for delivery receipts.
             std::unique_ptr<ReceiptTracker> receipt;
+
+            /// A handle to a cryptographic utility class.
+            std::unique_ptr<EncryptionLayer> crypto;
 
             /// The unique ID number of this remote endpoint. May be zero if handshake incomplete.
             PeerID id;

--- a/source/WirefoxConfigRefs.h
+++ b/source/WirefoxConfigRefs.h
@@ -33,6 +33,7 @@
 // DefaultEncryption
 #ifdef WIREFOX_ENABLE_ENCRYPTION
 #include "EncryptionLayerSodium.h"
+#include "EncryptionAuthenticator.h"
 #else
 #include "EncryptionLayerNull.h"
 #endif

--- a/source/WirefoxConfigRefs.h
+++ b/source/WirefoxConfigRefs.h
@@ -29,3 +29,10 @@
 
 // DefaultCongestionControl
 #include "CongestionControlWindow.h"
+
+// DefaultEncryption
+#ifdef WIREFOX_ENABLE_ENCRYPTION
+#include "EncryptionLayerSodium.h"
+#else
+#include "EncryptionLayerNull.h"
+#endif


### PR DESCRIPTION
This branch implements encryption using libsodium, and exposes new APIs to IPeer.

By default, all peers generate random keypairs on startup, and generate unique session keys during a key exchange. Optionally, either or both peers can be configured to use a preset keypair, enabling some degree of protection against MITMs.

Known issues:

- [x] Any out-of-band packets sent after handshaking (e.g. graceful disconnect ACK), will be misinterpreted as encrypted, causing an assert failure.
- [x] Clients that know a server's public key, should send them a challenge to verify that they actually own the private key.